### PR TITLE
fix error of duplicate interface in eventEmitter for RN0.40.0 

### DIFF
--- a/ios/RazorpayEventEmitter.m
+++ b/ios/RazorpayEventEmitter.m
@@ -7,8 +7,6 @@
 //
 
 #import "RazorpayEventEmitter.h"
-
-#import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
 
 NSString *const kPaymentError = @"PAYMENT_ERROR";


### PR DESCRIPTION
-for npm and auto link.