### PR TITLE
fix: use react-native convention for version overrides, allows AndroidX to work

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,13 +2,17 @@ apply plugin: 'com.android.library'
 repositories {
     mavenCentral()
 }
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION

This implements the standard way that react-native modules allow for overrides, and moves the default to 28 so AndroidX will work, otherwise users can't jetify your library and use AndroidX dependencies.

Mentioned here: https://github.com/react-native-community/react-native-netinfo/issues/107#issuecomment-503453199