### PR TITLE
Fixed: Open method not working on iOS

### DIFF
--- a/ios/RazorpayCheckout.m
+++ b/ios/RazorpayCheckout.m
@@ -30,11 +30,22 @@ RCT_EXPORT_METHOD(open : (NSDictionary *)options) {
                                andDelegateWithData:self];
         [razorpay setExternalWalletSelectionDelegate:self];
         
-  NSMutableDictionary * tempOptions = [[NSMutableDictionary alloc] initWithDictionary:options];
-//   tempOptions[@"integration_version"] = [self findReactNativeVersion];
-  tempOptions[@"integration"] = @"react-native";
-  tempOptions[@"FRAMEWORK"] = @"react-native";
-  [razorpay open:tempOptions];
+        NSMutableDictionary * tempOptions = [[NSMutableDictionary alloc] initWithDictionary:options];
+        //tempOptions[@"integration_version"] = [self findReactNativeVersion];
+        tempOptions[@"integration"] = @"react-native";
+        tempOptions[@"FRAMEWORK"] = @"react-native";
+        
+        //get root view to present razorpay vc
+        id<UIApplicationDelegate> app = [[UIApplication sharedApplication] delegate];
+        UINavigationController *rootViewController = ((UINavigationController*) app.window.rootViewController);
+        
+        if (rootViewController.presentedViewController) {
+            [razorpay open:tempOptions displayController:rootViewController.presentedViewController];
+            return;
+        }
+        
+        //Use 'open' method with displayController parameter
+        [razorpay open:tempOptions displayController:rootViewController];
     });
 }
 


### PR DESCRIPTION
By looking at the warning "Attempt to present <UINavigationController: 0x7fd50b91b600> on <UIViewController: 0x7fd50ac01fc0> which is already presenting <RCTModalHostViewController: 0x7fd50ae2fbf0>" I have added a code that will allow application to Present razorpay vc from root view controller.

The same issue #164  has been raised already and the solution to add an arbitrary delay before calling the 'open' method did not work for me.