### PR TITLE
Fix unable to resolve dependency tree error

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url": "git+https://github.com/razorpay/react-native-razorpay.git"
   },
   "peerDependencies": {
-    "react": "^17.0.0",
-    "react-native": "^0.66.4"
+    "react": "*",
+    "react-native": "*"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: xyz@1.5.32
npm ERR! Found: react-native@0.66.2
npm ERR! node_modules/react-native
npm ERR!   react-native@"0.66.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react-native@"^0.66.4" from react-native-razorpay@2.2.9
npm ERR! node_modules/react-native-razorpay
npm ERR!   react-native-razorpay@"^2.2.9" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/pushpendersingh/.npm/eresolve-report.txt for a full report.
```
