### PR TITLE
fix: correct new architecture detection for RN 0.74+

### DIFF
--- a/RazorpayCheckout.js
+++ b/RazorpayCheckout.js
@@ -2,8 +2,12 @@
 
 import { NativeModules, NativeEventEmitter } from 'react-native';
 
-// Runtime detection for new architecture
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+// Runtime detection for new architecture.
+// RN <0.74 uses __turboModuleProxy; RN >=0.74 (bridgeless) exposes TurboModuleRegistry and nativeFabricUIManager instead.
+const isTurboModuleEnabled =
+  global.__turboModuleProxy != null ||
+  global.TurboModuleRegistry != null ||
+  global.nativeFabricUIManager != null;
 
 let RazorpayCheckoutModule;
 let RazorpayEventEmitterModule;


### PR DESCRIPTION
global.__turboModuleProxy is no longer set in React Native 0.74+ bridgeless mode. Added checks for TurboModuleRegistry and nativeFabricUIManager which are the correct indicators for new architecture in RN 0.74 and above.

Verified on RN 0.83 Android and iOS - both old arch and new arch.

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |
