### PR TITLE
fix: exclude Android build artifacts and dev files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,34 @@
-example/*
+example/
 DeploymentScripts/
+Scripts/
+
+# Android build artifacts
+android/build/
+android/.gradle/
+android/.idea/
+android/local.properties
+
+# iOS build artifacts
+ios/build/
+ios/DerivedData/
+
+# OS files
+.DS_Store
+
+# IDE files
+.idea/
+*.iml
+
+# Git
+.github/
+
+# CI
+.semgrepignore
+.cursorignore
+
+# Claude Code
+.claude/
+
+# Dev files
+sampleApps/
+yarn.lock


### PR DESCRIPTION
The `.npmignore` was only excluding `example/` and `DeploymentScripts/`, so CI build artifacts were being included in the published npm package.

After `npm install`, we had ~1.2MB in `android/` due to gradle build output and other intermediates. These increase package size and can disrupt Android Studio when it scans `node_modules`.

I expanded `.npmignore` to exclude build artifacts, IDE files, CI config, and dev-only files.

Unpacked package size reduced from ~1.2MB to ~170KB after this change.