### PR TITLE
feat(magic): add openMagicCheckout() for Shopify Magic Checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ e2e/artifacts/*.mp4
 e2e/artifacts/*.log
 e2e/artifacts/*.dtxrec
 *.detox.log
+
+# Orchestration scratch workspace (ledgers, briefs, review packages)
+.slash-cli/

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,18 @@
 example/*
 DeploymentScripts/
+
+# Test tooling and suites — added alongside the Magic Checkout work.
+# Consumers get the library, not its tests: before that work this package had
+# no tests at all, so .npmignore never needed to exclude them.
+__tests__/
+__mocks__/
+src/**/__tests__/
+jest.config.js
+babel.config.js
+
+# Design records, implementation plans and local scratch. Note npm ignores
+# .gitignore entirely once .npmignore exists, so these need naming here even
+# though git already excludes some of them.
+docs/
+planning/
+tmp/

--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,61 @@ babel.config.js
 docs/
 planning/
 tmp/
+.slash-cli/
+
+# Everything below restores what .gitignore was silently supplying before this
+# file existed. Without it a maintainer's working copy leaks into the tarball —
+# the release process is a manual local `npm publish`, so whatever happens to be
+# lying around at publish time is what merchants download.
+
+# Editor, IDE and agent-tool state
+.idea/
+/.vscode/
+*.iml
+.playwright-mcp/
+.cursorignore
+.semgrepignore
+.DS_Store
+
+# Build output and local toolchain state
+build/
+.gradle/
+local.properties
+buck-out/
+\.buckd/
+android/app/libs
+android/keystores/debug.keystore
+node_modules/
+.yarn/
+npm-debug.log
+*-lock.json
+
+# Xcode local artefacts
+xcuserdata
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+*.xccheckout
+*.moved-aside
+*.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+project.xcworkspace
+
+# Detox E2E artefacts
+e2e/artifacts/*
+*.detox.log
+
+# Repo-maintenance material: nothing here is consumed by an installing app.
+/.github/
+/Scripts/
+CLAUDE.md
+CONTRIBUTING.md
+ReleaseHelper.md
+code_of_conduct.md
+
+# Diagram exports at the repo root only — the sample apps' own icon assets are
+# left alone so a shipped sample still builds.
+/*.png

--- a/.npmignore
+++ b/.npmignore
@@ -4,11 +4,11 @@ DeploymentScripts/
 # Test tooling and suites — added alongside the Magic Checkout work.
 # Consumers get the library, not its tests: before that work this package had
 # no tests at all, so .npmignore never needed to exclude them.
-__tests__/
-__mocks__/
+/__tests__/
+/__mocks__/
 src/**/__tests__/
-jest.config.js
-babel.config.js
+/jest.config.js
+/babel.config.js
 
 # Design records, implementation plans and local scratch. Note npm ignores
 # .gitignore entirely once .npmignore exists, so these need naming here even

--- a/README.md
+++ b/README.md
@@ -283,9 +283,11 @@ try {
 ### Pending is not a failure
 
 When `openMagicCheckout` resolves with `status: 'pending'`, Razorpay has already received
-and accepted the payment — its backend worker is placing the Shopify order asynchronously,
-retrying automatically (roughly at 5, 10 and 15 minutes) and refunding the payment if every
-attempt fails. This is a **success path**, not an error.
+and accepted the payment, and its backend continues attempting to place the Shopify order
+asynchronously. This is a **success path**, not an error. The retry schedule and what
+happens if placement never succeeds are owned by Razorpay's backend and documented at
+[razorpay.com/docs](https://razorpay.com/docs/) — they are not behaviour this SDK controls,
+so do not build your integration around specific timings.
 
 Show the shopper something like "We're confirming your order" — never "Your order failed."
 Telling a shopper their successful, paid order failed is a worse outcome than saying
@@ -301,24 +303,30 @@ Every rejection from `openMagicCheckout` carries three fields:
 | `error.reason` | A specific, queryable cause string (e.g. `user_cancelled`, `missing_cart_id`) |
 | `error.details` | Diagnostic and recovery context — see below |
 
-On a failure that happens **after the payment already succeeded** (order confirmation
+On a rejection that happens **after the payment already succeeded** (order confirmation
 failing to reach Razorpay), `error.details.handle` is populated with the exact payload
-needed to retry order confirmation — including `razorpay_signature` and your `key`. This is
-deliberate: it is the only way to recover a payment that was captured but never turned into
-a Shopify order.
+Razorpay needs to confirm the order — including `razorpay_signature` and your `key`. This is
+deliberate: it gives your app something to reference, and to retry with, for a payment that
+was captured but has not yet become a Shopify order.
 
 **Never blind-log `error.details` (or `error.details.handle`) to a crash reporter, analytics
 tool, or any third-party logging service.** Doing so ships a live Razorpay payment signature
 off-device. For monitoring and triage, log `error.code` and `error.reason` only. Persist
-`error.details.handle` yourself, in your own secure storage, solely for the retry described
-next.
+`error.details.handle` yourself, in your own secure storage, solely for the in-session retry
+described next.
 
-### Recovering a payment whose order did not confirm
+### When order confirmation does not complete
 
-If your app is killed between the payment succeeding and Razorpay confirming the Shopify
-order, `openMagicCheckout` may never resolve or reject — the promise is simply gone.
-Everything needed to retry is already in the handle described above, so persist it as soon
-as you have it and replay it later with a plain POST, no extra SDK call required:
+**What the SDK gives you, and when.** The handle reaches your app in exactly one place:
+`error.details.handle`, on a rejection from `openMagicCheckout`. That means your app is
+still running when you receive it. There is no callback, event or other API that hands you
+the handle earlier — so the only recovery you can drive from the client is a retry made
+while the app that started the checkout is still alive.
+
+**If the app is still alive.** Retrying with the same handle is safe: Razorpay de-duplicates
+order placement for a given Razorpay order, so replaying an identical handle within the
+idempotency window will not create a second Shopify order. The confirmation call is a plain
+POST of the handle, roughly:
 
 ```
 POST https://api.razorpay.com/v1/1cc/shopify/complete?key_id=<key>
@@ -330,8 +338,18 @@ POST https://api.razorpay.com/v1/1cc/shopify/complete?key_id=<key>
 }
 ```
 
-Retrying is safe: Razorpay guarantees at most one Shopify order per Razorpay order within a
-24-hour window, so replaying the same handle multiple times cannot create duplicate orders.
+That URL is **illustrative only**. The confirmation route Razorpay uses for a given merchant
+is chosen server-side and is not always this path, and the SDK does not expose which one
+applies to you — so do not hardcode it. Check
+[razorpay.com/docs](https://razorpay.com/docs/), or ask Razorpay support, before building a
+direct confirmation call. Do not call `openMagicCheckout` again to recover: that starts a
+new checkout and takes a second payment.
+
+**If the app is killed** between the payment succeeding and confirmation completing, the
+promise is gone and no handle was ever delivered — client-side recovery is not possible.
+Nothing your app can do covers this case. Razorpay's backend owns order placement from the
+moment it has the payment and continues attempting it asynchronously; that path, not the
+app, is what resolves this scenario.
 
 ### Not supported in this release
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ React Native wrapper around our Android and iOS mobile SDKs
 * [Proguard Rules](#proguard-rules)
 * [Notes](#things-to-be-taken-care)
 * [FAQ's](#faqs)
+* [Magic Checkout (Shopify)](#magic-checkout-shopify)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -240,6 +241,102 @@ If you are using proguard for your builds, you need to add following lines to pr
       ```
     - P.S: The apps won't be visible if the application is run with metro builder. The info.plist is generated successfully and integrated only when the app is built as standalone app.  
 - Still having trouble with integrating our payment gateway? Follow [this link](https://github.com/razorpay/react-native-razorpay/wiki/FAQ's) for more info.
+
+## Magic Checkout (Shopify)
+
+Magic Checkout (1CC) lets Shopify merchants offer a one-click checkout inside your React
+Native app. It requires the merchant to be 1CC-enabled on Shopify server-side — there is no
+SDK flag that turns it on from the app.
+
+```js
+import RazorpayCheckout from 'react-native-razorpay';
+
+try {
+  const result = await RazorpayCheckout.openMagicCheckout({
+    key: 'rzp_live_xxxxxxxx',
+    storefront_access_token: '<your Shopify Storefront access token>',
+    cart_id: 'gid://shopify/Cart/c1-abcdef',
+  });
+
+  if (result.status === 'placed') {
+    // The Shopify order exists. result.order_id and result.order_status_url are set.
+  } else {
+    // result.status === 'pending'. This is NOT a failure — see below.
+  }
+} catch (error) {
+  // error.code is one of: MAGIC_ORDER_CREATE_FAILED, MAGIC_CHECKOUT_CANCELLED,
+  // MAGIC_PAYMENT_FAILED, MAGIC_COMPLETE_FAILED, MAGIC_INVALID_OPTIONS.
+  // Log error.code and error.reason for triage — see "Handling errors safely"
+  // below before you touch error.details.
+  console.log(error.code, error.reason);
+}
+```
+
+### Parameters
+
+| Parameter | Required | Notes |
+|---|---|---|
+| `key` | yes | Your Razorpay public `key_id` — the same one you already use for `RazorpayCheckout.open` |
+| `storefront_access_token` | yes | **Your app's own** Shopify Storefront access token, not the merchant's. A Storefront cart is only readable by the app that created it, so the token has to be yours |
+| `cart_id` | yes | The Storefront cart's **id** (e.g. `gid://shopify/Cart/c1-abcdef`) — an identifier, never the cart object itself. Passing a cart object is rejected; amounts and line items always stay server-side |
+
+### Pending is not a failure
+
+When `openMagicCheckout` resolves with `status: 'pending'`, Razorpay has already received
+and accepted the payment — its backend worker is placing the Shopify order asynchronously,
+retrying automatically (roughly at 5, 10 and 15 minutes) and refunding the payment if every
+attempt fails. This is a **success path**, not an error.
+
+Show the shopper something like "We're confirming your order" — never "Your order failed."
+Telling a shopper their successful, paid order failed is a worse outcome than saying
+nothing.
+
+### Handling errors safely
+
+Every rejection from `openMagicCheckout` carries three fields:
+
+| Field | Contents |
+|---|---|
+| `error.code` | One of `MAGIC_ORDER_CREATE_FAILED`, `MAGIC_CHECKOUT_CANCELLED`, `MAGIC_PAYMENT_FAILED`, `MAGIC_COMPLETE_FAILED`, `MAGIC_INVALID_OPTIONS` |
+| `error.reason` | A specific, queryable cause string (e.g. `user_cancelled`, `missing_cart_id`) |
+| `error.details` | Diagnostic and recovery context — see below |
+
+On a failure that happens **after the payment already succeeded** (order confirmation
+failing to reach Razorpay), `error.details.handle` is populated with the exact payload
+needed to retry order confirmation — including `razorpay_signature` and your `key`. This is
+deliberate: it is the only way to recover a payment that was captured but never turned into
+a Shopify order.
+
+**Never blind-log `error.details` (or `error.details.handle`) to a crash reporter, analytics
+tool, or any third-party logging service.** Doing so ships a live Razorpay payment signature
+off-device. For monitoring and triage, log `error.code` and `error.reason` only. Persist
+`error.details.handle` yourself, in your own secure storage, solely for the retry described
+next.
+
+### Recovering a payment whose order did not confirm
+
+If your app is killed between the payment succeeding and Razorpay confirming the Shopify
+order, `openMagicCheckout` may never resolve or reject — the promise is simply gone.
+Everything needed to retry is already in the handle described above, so persist it as soon
+as you have it and replay it later with a plain POST, no extra SDK call required:
+
+```
+POST https://api.razorpay.com/v1/1cc/shopify/complete?key_id=<key>
+{
+  "razorpay_order_id":   "...",
+  "razorpay_payment_id": "...",
+  "razorpay_signature":  "...",
+  "key":                 "..."
+}
+```
+
+Retrying is safe: Razorpay guarantees at most one Shopify order per Razorpay order within a
+24-hour window, so replaying the same handle multiple times cannot create duplicate orders.
+
+### Not supported in this release
+
+Analytics fan-out (GA4, Facebook Pixel, MoEngage, CleverTap), coupon prefill UI,
+abandoned-cart recovery, loyalty coins, gift cards, and WooCommerce or Magento storefronts.
 
 ## Contributing
 

--- a/RazorpayCheckout.js
+++ b/RazorpayCheckout.js
@@ -6,6 +6,24 @@ import {
   removeSubscriptions,
   runCheckout,
 } from './src/internal/checkoutSession';
+import { createMagicCheckout } from './src/magic/core';
+import {
+  createReactNativeHost,
+  createFetchHttp,
+} from './src/magic/adapters/reactNative';
+
+// Built lazily so importing RazorpayCheckout.js never touches the native
+// bridge until a Magic checkout is actually requested.
+let magic;
+function getMagic() {
+  if (!magic) {
+    magic = createMagicCheckout({
+      host: createReactNativeHost(),
+      http: createFetchHttp(),
+    });
+  }
+  return magic;
+}
 
 class RazorpayCheckout {
   static open(options, successCallback, errorCallback) {
@@ -16,6 +34,10 @@ class RazorpayCheckout {
         teardown: removeSubscriptions,
       });
     });
+  }
+
+  static openMagicCheckout(options) {
+    return getMagic().openMagicCheckout(options);
   }
 
   static onExternalWalletSelection(externalWalletCallback) {

--- a/RazorpayCheckout.js
+++ b/RazorpayCheckout.js
@@ -1,59 +1,25 @@
 'use strict';
 
-import { NativeModules, NativeEventEmitter } from 'react-native';
-
-// Runtime detection for new architecture.
-// RN <0.74 uses __turboModuleProxy; RN >=0.74 (bridgeless) exposes TurboModuleRegistry and nativeFabricUIManager instead.
-const isTurboModuleEnabled =
-  global.__turboModuleProxy != null ||
-  global.TurboModuleRegistry != null ||
-  global.nativeFabricUIManager != null;
-
-let RazorpayCheckoutModule;
-let RazorpayEventEmitterModule;
-
-if (isTurboModuleEnabled) {
-  // New Architecture - Try to load TurboModule specs
-  try {
-    RazorpayCheckoutModule = require('./src/NativeRazorpayCheckout').default;
-    RazorpayEventEmitterModule = require('./src/NativeRazorpayEventEmitter').default;
-  } catch (error) {
-    // Fallback to old architecture if TurboModule not available
-    RazorpayCheckoutModule = NativeModules.RNRazorpayCheckout;
-    RazorpayEventEmitterModule = NativeModules.RazorpayEventEmitter;
-  }
-} else {
-  // Old Architecture
-  RazorpayCheckoutModule = NativeModules.RNRazorpayCheckout;
-  RazorpayEventEmitterModule = NativeModules.RazorpayEventEmitter;
-}
-
-const razorpayEvents = new NativeEventEmitter(RazorpayEventEmitterModule);
-
-const removeSubscriptions = () => {
-  razorpayEvents.removeAllListeners('Razorpay::PAYMENT_SUCCESS');
-  razorpayEvents.removeAllListeners('Razorpay::PAYMENT_ERROR');
-  razorpayEvents.removeAllListeners('Razorpay::EXTERNAL_WALLET_SELECTED');
-};
+import {
+  EVENT_NAMES,
+  getEmitter,
+  removeSubscriptions,
+  runCheckout,
+} from './src/internal/checkoutSession';
 
 class RazorpayCheckout {
   static open(options, successCallback, errorCallback) {
-    return new Promise(function(resolve, reject) {
-      razorpayEvents.addListener('Razorpay::PAYMENT_SUCCESS', (data) => {
-        let resolveFn = successCallback || resolve;
-        resolveFn(data);
-        removeSubscriptions();
+    return new Promise(function (resolve, reject) {
+      runCheckout(options, {
+        onSuccess: (data) => (successCallback || resolve)(data),
+        onError: (data) => (errorCallback || reject)(data),
+        teardown: removeSubscriptions,
       });
-      razorpayEvents.addListener('Razorpay::PAYMENT_ERROR', (data) => {
-        let rejectFn = errorCallback || reject;
-        rejectFn(data);
-        removeSubscriptions();
-      });
-      RazorpayCheckoutModule.open(options);
     });
   }
+
   static onExternalWalletSelection(externalWalletCallback) {
-    razorpayEvents.addListener('Razorpay::EXTERNAL_WALLET_SELECTED', (data) => {
+    getEmitter().addListener(EVENT_NAMES.EXTERNAL_WALLET, (data) => {
       externalWalletCallback(data);
       removeSubscriptions();
     });

--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -1,0 +1,38 @@
+class NativeEventEmitter {
+  constructor(nativeModule) {
+    this.nativeModule = nativeModule;
+    this.listeners = {};
+    NativeEventEmitter.instances.push(this);
+  }
+
+  addListener(event, cb) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(cb);
+    return { remove: () => this.removeListener(event, cb) };
+  }
+
+  removeListener(event, cb) {
+    this.listeners[event] = (this.listeners[event] || []).filter((f) => f !== cb);
+  }
+
+  removeAllListeners(event) {
+    this.listeners[event] = [];
+  }
+
+  emit(event, data) {
+    (this.listeners[event] || []).slice().forEach((cb) => cb(data));
+  }
+
+  listenerCount(event) {
+    return (this.listeners[event] || []).length;
+  }
+}
+
+NativeEventEmitter.instances = [];
+
+const NativeModules = {
+  RNRazorpayCheckout: { open: jest.fn() },
+  RazorpayEventEmitter: { addListener: jest.fn(), removeListeners: jest.fn() },
+};
+
+module.exports = { NativeModules, NativeEventEmitter };

--- a/__tests__/helpers/suite.js
+++ b/__tests__/helpers/suite.js
@@ -1,0 +1,24 @@
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+// Each suite loads the SDK fresh. RazorpayCheckout.js builds a module-scoped
+// NativeEventEmitter at import time, so without resetModules one test's
+// listeners leak into the next and failures look like ordering flakes.
+// resetModules also gives a fresh react-native mock, so `instances` starts
+// empty and the last entry is always this suite's emitter.
+function makeSuite() {
+  jest.resetModules();
+  const RN = require('react-native');
+  const RazorpayCheckout = require(path.join(ROOT, 'RazorpayCheckout.js')).default;
+  const emitter = RN.NativeEventEmitter.instances[RN.NativeEventEmitter.instances.length - 1];
+  return { RN, RazorpayCheckout, emitter, native: RN.NativeModules.RNRazorpayCheckout };
+}
+
+const EVENTS = {
+  success: 'Razorpay::PAYMENT_SUCCESS',
+  error: 'Razorpay::PAYMENT_ERROR',
+  wallet: 'Razorpay::EXTERNAL_WALLET_SELECTED',
+};
+
+module.exports = { makeSuite, EVENTS };

--- a/__tests__/infra.test.js
+++ b/__tests__/infra.test.js
@@ -1,0 +1,23 @@
+const { makeSuite, EVENTS } = require('./helpers/suite');
+
+describe('test infrastructure', () => {
+  const cases = {
+    'should load the SDK then expose open': (ts) => {
+      expect(typeof ts.RazorpayCheckout.open).toBe('function');
+    },
+    'should build an event emitter then expose emit': (ts) => {
+      expect(typeof ts.emitter.emit).toBe('function');
+    },
+    'should reach the native module then expose open': (ts) => {
+      expect(typeof ts.native.open).toBe('function');
+    },
+    'should register a success listener then count one': (ts) => {
+      ts.emitter.addListener(EVENTS.success, () => {});
+      expect(ts.emitter.listenerCount(EVENTS.success)).toBe(1);
+    },
+  };
+
+  Object.entries(cases).forEach(([name, assertion]) => {
+    it(name, () => assertion(makeSuite()));
+  });
+});

--- a/__tests__/magic.integration.test.js
+++ b/__tests__/magic.integration.test.js
@@ -51,6 +51,40 @@ describe('openMagicCheckout through the RN adapter', () => {
     await expect(promise).resolves.toMatchObject({ order_id: 'shop_1', status: 'placed' });
   });
 
+  // MB1, end to end through the real adapter. Phase 3 runs after the payment
+  // has been captured, so a socket that accepts the request and goes silent is
+  // the worst case on this branch: without a wall-clock bound the promise never
+  // settles and the merchant never even receives the recovery handle. Without
+  // the fix this test does not fail an assertion, it hangs.
+  it('should bound a silent phase three then resolve as pending inside the budget', async () => {
+    let call = 0;
+    global.fetch.mockImplementation((url, init) => {
+      call += 1;
+      if (call === 1) {
+        return Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve({ order_id: 'order_1', poll_budget_ms: 100 }),
+        });
+      }
+      return new Promise((resolve, reject) => {
+        const signal = init && init.signal;
+        if (signal) signal.addEventListener('abort', () => reject(new Error('Aborted')));
+      });
+    });
+
+    const ts = makeSuite();
+    const promise = ts.RazorpayCheckout.openMagicCheckout(OPTIONS);
+    await new Promise((r) => setImmediate(r));
+
+    ts.emitter.emit(EVENTS.success, {
+      razorpay_payment_id: 'pay_1',
+      razorpay_order_id: 'order_1',
+      razorpay_signature: 'sig_1',
+    });
+
+    await expect(promise).resolves.toMatchObject({ status: 'pending', payment_id: 'pay_1' });
+  });
+
   it('should leave open() untouched then keep its listeners working', async () => {
     const ts = makeSuite();
     const promise = ts.RazorpayCheckout.open({ key: 'k' });

--- a/__tests__/magic.integration.test.js
+++ b/__tests__/magic.integration.test.js
@@ -1,0 +1,94 @@
+const { makeSuite, EVENTS } = require('./helpers/suite');
+
+describe('openMagicCheckout through the RN adapter', () => {
+  const OPTIONS = {
+    key: 'rzp_test_k',
+    storefront_access_token: 'sf-token',
+    cart_id: 'gid://shopify/Cart/c1-abc',
+  };
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  function respond(bodies) {
+    const queue = bodies.slice();
+    global.fetch.mockImplementation(() => {
+      const next = queue.shift();
+      return Promise.resolve({
+        status: next.status,
+        json: () => Promise.resolve(next.body),
+      });
+    });
+  }
+
+  it('should open the native modal then resolve after completion', async () => {
+    respond([
+      { status: 200, body: { order_id: 'order_1', experiments: {} } },
+      { status: 200, body: { order_id: 'shop_1', order_status_url: 'https://s/o/1' } },
+    ]);
+    const ts = makeSuite();
+
+    const promise = ts.RazorpayCheckout.openMagicCheckout(OPTIONS);
+    await new Promise((r) => setImmediate(r));
+
+    expect(ts.native.open).toHaveBeenCalledWith({
+      key: 'rzp_test_k',
+      order_id: 'order_1',
+      one_click_checkout: true,
+    });
+
+    ts.emitter.emit(EVENTS.success, {
+      razorpay_payment_id: 'pay_1',
+      razorpay_order_id: 'order_1',
+      razorpay_signature: 'sig_1',
+    });
+
+    await expect(promise).resolves.toMatchObject({ order_id: 'shop_1', status: 'placed' });
+  });
+
+  it('should leave open() untouched then keep its listeners working', async () => {
+    const ts = makeSuite();
+    const promise = ts.RazorpayCheckout.open({ key: 'k' });
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_2' });
+    await expect(promise).resolves.toEqual({ razorpay_payment_id: 'pay_2' });
+  });
+
+  it('should release its listener then leave none registered after Magic resolves', async () => {
+    respond([
+      { status: 200, body: { order_id: 'order_1' } },
+      { status: 200, body: {} },
+    ]);
+    const ts = makeSuite();
+    const promise = ts.RazorpayCheckout.openMagicCheckout(OPTIONS);
+    await new Promise((r) => setImmediate(r));
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_1' });
+    await promise;
+    expect(ts.emitter.listenerCount(EVENTS.success)).toBe(0);
+  });
+
+  // Discriminator: emptying the success-listener count to zero is not proof
+  // of per-call teardown by itself, since removeSubscriptions() also drives
+  // it to zero (by clearing globally). A bystander listener registered on a
+  // *different* event before Magic starts is the thing that only survives if
+  // Magic's unsubscribe removes exactly the two handles it added.
+  it('should leave an unrelated wallet listener registered then not touch it on Magic teardown', async () => {
+    respond([
+      { status: 200, body: { order_id: 'order_1' } },
+      { status: 200, body: {} },
+    ]);
+    const ts = makeSuite();
+    ts.RazorpayCheckout.onExternalWalletSelection(() => {});
+
+    const promise = ts.RazorpayCheckout.openMagicCheckout(OPTIONS);
+    await new Promise((r) => setImmediate(r));
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_1' });
+    await promise;
+
+    expect(ts.emitter.listenerCount(EVENTS.wallet)).toBe(1);
+  });
+});

--- a/__tests__/open.regression.test.js
+++ b/__tests__/open.regression.test.js
@@ -22,6 +22,22 @@ describe('open() behaviour is frozen', () => {
     await expect(promise).rejects.toEqual({ code: 0, description: 'cancelled' });
   });
 
+  // Ordering matters: the native SDK can emit its result as soon as it launches.
+  // If listener registration happens after the native open() call, that emission
+  // has no listener to catch it and the promise never settles, orphaning the
+  // payment. Capture listener count from inside the native mock's own
+  // implementation so we see state at the exact moment open() is invoked,
+  // rather than after — a post-hoc check can't tell the two orderings apart.
+  it('should register listeners then call native open', () => {
+    const ts = makeSuite();
+    let listenersAtCallTime = -1;
+    ts.native.open.mockImplementation(() => {
+      listenersAtCallTime = ts.emitter.listenerCount(EVENTS.success);
+    });
+    ts.RazorpayCheckout.open({ key: 'k' });
+    expect(listenersAtCallTime).toBe(1);
+  });
+
   it('should prefer successCallback then never resolve the promise', async () => {
     const ts = makeSuite();
     const onSuccess = jest.fn();

--- a/__tests__/open.regression.test.js
+++ b/__tests__/open.regression.test.js
@@ -1,0 +1,67 @@
+const { makeSuite, EVENTS } = require('./helpers/suite');
+
+describe('open() behaviour is frozen', () => {
+  it('should call the native module then pass options through untouched', () => {
+    const ts = makeSuite();
+    const options = { key: 'rzp_test_1', amount: '100', nested: { a: [1, 2] } };
+    ts.RazorpayCheckout.open(options);
+    expect(ts.native.open).toHaveBeenCalledWith(options);
+  });
+
+  it('should resolve the promise then return the success payload', async () => {
+    const ts = makeSuite();
+    const promise = ts.RazorpayCheckout.open({ key: 'k' });
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_1' });
+    await expect(promise).resolves.toEqual({ razorpay_payment_id: 'pay_1' });
+  });
+
+  it('should reject the promise then return the error payload', async () => {
+    const ts = makeSuite();
+    const promise = ts.RazorpayCheckout.open({ key: 'k' });
+    ts.emitter.emit(EVENTS.error, { code: 0, description: 'cancelled' });
+    await expect(promise).rejects.toEqual({ code: 0, description: 'cancelled' });
+  });
+
+  it('should prefer successCallback then never resolve the promise', async () => {
+    const ts = makeSuite();
+    const onSuccess = jest.fn();
+    let settled = false;
+    ts.RazorpayCheckout.open({ key: 'k' }, onSuccess).then(() => { settled = true; });
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_1' });
+    await Promise.resolve();
+    expect(onSuccess).toHaveBeenCalledWith({ razorpay_payment_id: 'pay_1' });
+    expect(settled).toBe(false);
+  });
+
+  it('should prefer errorCallback then never reject the promise', async () => {
+    const ts = makeSuite();
+    const onError = jest.fn();
+    const promise = ts.RazorpayCheckout.open({ key: 'k' }, undefined, onError);
+    promise.catch(() => { throw new Error('promise must not reject'); });
+    ts.emitter.emit(EVENTS.error, { code: 2 });
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledWith({ code: 2 });
+  });
+
+  // QUIRK, DELIBERATELY LOCKED: teardown is global, not per-call. Anything that
+  // "fixes" this changes shipped behaviour for every existing integration.
+  it('should remove every listener on first success then leave zero registered', () => {
+    const ts = makeSuite();
+    ts.RazorpayCheckout.open({ key: 'k' });
+    ts.RazorpayCheckout.onExternalWalletSelection(() => {});
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_1' });
+    expect(ts.emitter.listenerCount(EVENTS.success)).toBe(0);
+    expect(ts.emitter.listenerCount(EVENTS.error)).toBe(0);
+    expect(ts.emitter.listenerCount(EVENTS.wallet)).toBe(0);
+  });
+
+  // QUIRK, DELIBERATELY LOCKED: the wallet callback also tears down the payment
+  // listeners, so a wallet selection can orphan an in-flight open().
+  it('should remove payment listeners on wallet selection then leave zero registered', () => {
+    const ts = makeSuite();
+    ts.RazorpayCheckout.open({ key: 'k' });
+    ts.RazorpayCheckout.onExternalWalletSelection(() => {});
+    ts.emitter.emit(EVENTS.wallet, { external_wallet: 'paytm' });
+    expect(ts.emitter.listenerCount(EVENTS.success)).toBe(0);
+  });
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    '@babel/preset-typescript',
+  ],
+};

--- a/docs/superpowers/plans/2026-08-28-rn-magic-shopify.md
+++ b/docs/superpowers/plans/2026-08-28-rn-magic-shopify.md
@@ -2391,7 +2391,7 @@ export function createClient(http) {
 ```bash
 npm test -- src/magic/core/__tests__/client.test.js
 ```
-Expected: PASS, 11 tests.
+Expected: PASS, 10 tests.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-08-28-rn-magic-shopify.md
+++ b/docs/superpowers/plans/2026-08-28-rn-magic-shopify.md
@@ -1,0 +1,3161 @@
+# Magic Checkout (Shopify) for React Native — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Each task's implementation goes through `superpowers:test-driven-development`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a React Native app complete a Shopify Magic Checkout end-to-end in one SDK call — `RazorpayCheckout.openMagicCheckout({ key, storefront_access_token, cart_id })`.
+
+**Architecture:** The SDK is the orchestrator, exactly as `magic-plugins` is on web. It makes one call to a new `1cc-consumer-app` endpoint to get a Razorpay `order_id`, opens the **existing** native `open({ key, order_id })` path, and on payment success calls the Shopify complete endpoint. No native code changes. **No `checkout` (FE) changes.** No Shopify cart data ever reaches the device.
+
+**Tech Stack:** Go 1.x / gin / gomock (`1cc-consumer-app`); JavaScript (CommonJS-transpiled ES modules) / Jest / Babel (`react-native-razorpay`). No new runtime dependencies in the SDK — `fetch` is provided by React Native.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-rn-magic-shopify-design.md` (v7), which supersedes the architecture sections of `2026-08-25-rn-magic-shopify-design.md` (aidocs `doc_nlfwhc7wob4hgy7i`, v6).
+
+**Repositories in scope:**
+
+| Repo | Path | Work |
+|---|---|---|
+| `1cc-consumer-app` | `/Users/n.maneeshgupta/Documents/Codes/1cc-consumer-app` | Tasks 1–4: one new endpoint |
+| `react-native-razorpay` | `/Users/n.maneeshgupta/Documents/Codes/react-native-razorpay` | Tasks 5–13: test infra + orchestrator |
+| `checkout` (FE) | — | **No changes.** See Task 0 |
+
+---
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+**Both repos**
+
+- Log/event names are `UPPER_SNAKE_CASE` in `ACTION_STATUS` form with the specific cause in a queryable `reason` field — never baked into the name. `FETCH_CONFIGS_SUCCESS` / `FETCH_CONFIGS_FAILED` with `reason=timeout`, not `FETCH_CONFIGS_TIMEOUT_FAILED`.
+- Comments explain the business **why** and on-call context, never the mechanical what.
+- Tests are table-driven, `map[string]struct{...}` (Go) or `Object.entries` over a map (JS), keyed `"should X then Y"` so any single subtest runs in isolation.
+- Split files by functionality. No catch-all `helper.go`, `utils.js` or `magic.js`.
+
+**`1cc-consumer-app`**
+
+- Business/semantic validation goes in the **service layer** via `request.Validate(ctx)`. Controllers do transport-level parsing only.
+- Never log or return a Shopify credential, `storefront_access_token`, raw PII, or cart contents.
+- `ShopName` is **always** `*merchantConfig.ShopId`. Never from the request body. A client-supplied token must never be able to redirect an outbound call at another shop.
+- After changing any interface with a generated mock, run `make mock-gen`.
+- Run `make test-unit` before every commit.
+
+**`react-native-razorpay`**
+
+- **No new runtime dependencies.** Dev-only additions allowed. Never add `react-native-webview` or any storage library.
+- **`open()`'s public behaviour must not change** — including that listeners are removed after the first success, and that `successCallback`/`errorCallback` take precedence over the promise.
+- **Never send a monetary amount, line item, or cart object** in any request the SDK constructs, and never accept one as an option.
+- **Never call Shopify from the SDK.**
+- `src/magic/core/` must not `import` or `require` `react-native`, directly or transitively. Task 9 adds a test that enforces this.
+- Base URL: `https://api.razorpay.com/v1`.
+- Phase-2 modal options are exactly `{ key, order_id, one_click_checkout: true }`. No `shopify_cart`, no `magic_shop_id`.
+- Phase-3 client budget: **8000 ms** total wall clock, capped exponential backoff on 5xx, initial delay 500 ms, cap 2000 ms.
+- Native error codes, verified against `com.razorpay:standard-core` 1.7.18: `PAYMENT_CANCELED = 0`, `NETWORK_ERROR = 2`, `INVALID_OPTIONS = 3`, `TLS_ERROR = 6`, `INCOMPATIBLE_PLUGIN = 7`.
+- **Lock files:** `.gitignore` carries `*-lock.json`, so `package-lock.json` is never committed — `yarn.lock` is the tracked one. In this environment `npm install` is aliased to a `pmg npm` wrapper that rewrites `yarn.lock` as a side effect; after any `npm install`, run `git status` and `git checkout -- yarn.lock` if it was touched, before staging anything.
+
+---
+
+## File Structure
+
+### `1cc-consumer-app`
+
+| File | Responsibility |
+|---|---|
+| `pkg/shopify/client/graphql/queries.go` | **modify** — add `GetMobileCartDetailsQuery()` |
+| `internal/gateway/shopify/checkout/dtos/response/mobilecart.go` | **create** — `MobileCartResponse` and children |
+| `internal/gateway/shopify/checkout/mobilecart.go` | **create** — `GetMobileCartDetails` gateway method |
+| `internal/gateway/shopify/checkout/interfaces/interfaces.go` | **modify** — add `GetMobileCartDetails` to `ICheckoutGateway` |
+| `internal/checkout/mobiletransformers.go` | **create** — Storefront cart → `dtos.Cart` mapping |
+| `internal/checkout/dtos/mobile.go` | **create** — `MobileInitRequest` + `Validate` |
+| `internal/checkout/mobileinit.go` | **create** — `MobileInit` service method |
+| `internal/checkout/interfaces/interfaces.go` | **modify** — add `MobileInit` to `IService` |
+| `internal/controllers/checkout/mobile.go` | **create** — `MobileInit` controller |
+| `internal/routing/routercx/v1/checkout.go` | **modify** — register `POST /shopify/init` |
+| `internal/tracecodes/*.go` | **modify** — new trace codes |
+
+Mapping lives in `mobiletransformers.go`, not `common.go` — the repo/DTO-transform convention.
+
+### `react-native-razorpay`
+
+| File | Responsibility |
+|---|---|
+| `babel.config.js` | **create** — Babel presets for Jest |
+| `jest.config.js` | **create** — Jest config, maps `react-native` to the manual mock |
+| `__mocks__/react-native.js` | **create** — minimal `NativeModules` + `NativeEventEmitter` doubles |
+| `__tests__/helpers/suite.js` | **create** — suite factory returning a freshly-loaded SDK |
+| `__tests__/open.regression.test.js` | **create** — characterisation tests locking `open()` |
+| `src/internal/checkoutSession.js` | **create** — extracted listener wiring shared by `open()` and Magic |
+| `src/magic/core/errors.js` | **create** — `MagicCheckoutError` + code taxonomy |
+| `src/magic/core/endpoints.js` | **create** — paths and the Splitz-driven complete-route choice |
+| `src/magic/core/client.js` | **create** — the two HTTP calls, timeouts, outcome classification |
+| `src/magic/core/openMagicCheckout.js` | **create** — the three-phase orchestrator |
+| `src/magic/core/index.js` | **create** — `createMagicCheckout({ host, http })` factory |
+| `src/magic/adapters/reactNative.js` | **create** — `host` + `http` bound to the RN bridge |
+| `src/magic/core/__tests__/*.test.js` | **create** — unit, contract and orchestrator suites |
+| `RazorpayCheckout.js` | **modify** — delegate to `checkoutSession`, export `openMagicCheckout` |
+| `src/types.ts` | **modify** — add Magic types |
+| `package.json` | **modify** — devDependencies + `test` script |
+| `README.md` | **modify** — Magic Checkout section |
+
+---
+
+## Task 0: Verify the design on device — BLOCKING, no code
+
+This is the only check that can invalidate the architecture. Do it first. It needs no new code in any repo.
+
+The whole plan rests on: *Magic renders in the native SDK WebView given `order_id` alone, for a 1CC-enabled merchant.* That is derived from `checkout` FE source, not observed:
+
+- `isMagic()` returns true via `hasLineItemsTotal` from the order plus the server-side `hasFeature('one_click_checkout')` — `app/v2/modules/magic/common/helpers/isMagic.ts:20,22,26`
+- the Magic UI renders line items from `prefsOrder.line_items` / `line_items_total` when not in lite flow — `app/v2/modules/main-modal/helpers/magic.ts:176-180`
+- `shouldCreateShopifyCheckout()` / `shouldCreateShopifyOrder()` both return false, so `checkout.js` will **not** re-create the order — `app/v2/modules/magic/common/helpers/index.ts:316-330`
+- serviceability resolves to `'orderId'`, never touching `shopify_cart` — `app/v2/modules/magic/common/helpers/compute-shipping-method.ts:10-28`
+
+**Steps**
+
+- [ ] **Step 1: Get a 1CC order**
+
+Ask the Magic Checkout team for a 1CC-enabled **test** merchant key and create one Shopify Magic order by any existing means (web storefront is fine). Record its `order_id` and `key`.
+
+- [ ] **Step 2: Open it from the sample app**
+
+In `sampleApps/`, replace the options passed to `RazorpayCheckout.open` with exactly:
+
+```js
+RazorpayCheckout.open({
+  key: '<test key_id>',
+  order_id: '<order_id from step 1>',
+  one_click_checkout: true,
+})
+  .then((d) => console.log('SUCCESS', d))
+  .catch((e) => console.log('ERROR', e));
+```
+
+- [ ] **Step 3: Record the result on both platforms**
+
+Run on Android and iOS. Write down, for each:
+
+1. Does the **Magic UI** render — address form, shipping options, coupon field? (Not the standard checkout method list.)
+2. Is the amount correct and non-zero?
+3. Do shipping options load after entering a serviceable pincode?
+
+- [ ] **Step 4: Gate**
+
+All three yes on both platforms → the architecture holds. Proceed to Task 1.
+
+Any no → **stop and escalate.** Do not work around it. A "no" means `checkout.js` needs a change and the plan's shape changes; re-open the design record §5.2/§5.3 rather than patching. Record which of the four bullets above was false.
+
+---
+
+# Repo A — `1cc-consumer-app`
+
+Work from `/Users/n.maneeshgupta/Documents/Codes/1cc-consumer-app` on a feature branch off `master`. Load `.agents/skills/repo-skill/SKILL.md`, `.agents/skills/code-review/SKILL.md` and `.slash/reviewer-memory/learnings.yaml` before writing code, per this repo's `AGENTS.md`.
+
+## Task 1: Mobile cart Storefront query and gateway method
+
+Read AppBrew's Shopify cart using **their** Storefront access token.
+
+A separate query rather than extending `GetShopifyCartDetailsMutation()` (`pkg/shopify/client/graphql/queries.go:268`): that one is shared with the coupons path, and widening its selection set changes the Storefront response for existing callers and requires their token scopes to cover the new fields.
+
+**Files:**
+- Create: `internal/gateway/shopify/checkout/dtos/response/mobilecart.go`
+- Create: `internal/gateway/shopify/checkout/mobilecart.go`
+- Modify: `pkg/shopify/client/graphql/queries.go`
+- Modify: `internal/gateway/shopify/checkout/interfaces/interfaces.go`
+- Test: `internal/gateway/shopify/checkout/mobilecart_slit_test.go`
+
+**Interfaces:**
+- Consumes: `client.NewClient(ctx, models.Credentials, *hystrix.Client)`, `shopifyClient.MakeStorefrontRequest(models.GraphQLRequest)`
+- Produces: `ICheckoutGateway.GetMobileCartDetails(ctx context.Context, credentials *models.Credentials, cartID string) (*response.MobileCartResponse, errors.IError)`
+
+- [ ] **Step 1: Add the response DTO**
+
+Create `internal/gateway/shopify/checkout/dtos/response/mobilecart.go`:
+
+```go
+package response
+
+// MobileCartResponse models the Storefront `cart(id:)` read used by the native
+// Magic flow. It is deliberately separate from the coupon CheckoutResponse:
+// that type is shaped for a Checkout node and is shared with the coupons path,
+// so widening it would change behaviour for callers we are not touching.
+type MobileCartResponse struct {
+	Data *MobileCartData `json:"data"`
+}
+
+type MobileCartData struct {
+	Cart *MobileCart `json:"cart"`
+}
+
+type MobileCart struct {
+	Cost  *MobileCartCost  `json:"cost"`
+	Note  *string          `json:"note"`
+	Lines *MobileCartLines `json:"lines"`
+}
+
+type MobileCartCost struct {
+	TotalAmount *MobileMoney `json:"totalAmount"`
+}
+
+type MobileMoney struct {
+	Amount       string `json:"amount"`
+	CurrencyCode string `json:"currencyCode"`
+}
+
+type MobileCartLines struct {
+	Edges []MobileCartLineEdge `json:"edges"`
+}
+
+type MobileCartLineEdge struct {
+	Node *MobileCartLine `json:"node"`
+}
+
+type MobileCartLine struct {
+	Quantity    int64              `json:"quantity"`
+	Merchandise *MobileMerchandise `json:"merchandise"`
+}
+
+type MobileMerchandise struct {
+	ID               string         `json:"id"`
+	SKU              *string        `json:"sku"`
+	Title            *string        `json:"title"`
+	Weight           *float64       `json:"weight"`
+	WeightUnit       *string        `json:"weightUnit"`
+	RequiresShipping *bool          `json:"requiresShipping"`
+	Taxable          *bool          `json:"taxable"`
+	Price            *MobileMoney   `json:"price"`
+	Image            *MobileImage   `json:"image"`
+	Product          *MobileProduct `json:"product"`
+}
+
+type MobileImage struct {
+	URL *string `json:"url"`
+}
+
+type MobileProduct struct {
+	ID          string  `json:"id"`
+	Title       *string `json:"title"`
+	ProductType *string `json:"productType"`
+	Description *string `json:"description"`
+}
+```
+
+- [ ] **Step 2: Add the GraphQL query**
+
+Append to `pkg/shopify/client/graphql/queries.go`:
+
+```go
+// GetMobileCartDetailsQuery reads a Storefront cart for the native Magic flow.
+// Selects the superset of fields dtos.Item carries so the mobile mapper never
+// has to guess: image, productType, taxable and description are absent from
+// GetShopifyCartDetailsMutation and are why this is a separate query.
+func GetMobileCartDetailsQuery() string {
+	return `query MobileCart($cartID: ID!) {
+    cart(id: $cartID) {
+        note
+        cost {
+            totalAmount { amount currencyCode }
+        }
+        lines(first: 250) {
+            edges {
+                node {
+                    quantity
+                    merchandise {
+                        ... on ProductVariant {
+                            id
+                            sku
+                            title
+                            weight
+                            weightUnit
+                            requiresShipping
+                            taxable
+                            price { amount currencyCode }
+                            image { url }
+                            product {
+                                id
+                                title
+                                productType
+                                description
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`
+}
+```
+
+- [ ] **Step 3: Add the interface method**
+
+In `internal/gateway/shopify/checkout/interfaces/interfaces.go`, add to `ICheckoutGateway` immediately after `GetCartByStoreFrontId`:
+
+```go
+	GetMobileCartDetails(ctx context.Context,
+		credentials *models.Credentials,
+		cartID string,
+	) (*response.MobileCartResponse, errors.IError)
+```
+
+- [ ] **Step 4: Regenerate mocks**
+
+```bash
+make mock-gen
+```
+
+- [ ] **Step 5: Write the failing SLIT test**
+
+Create `internal/gateway/shopify/checkout/mobilecart_slit_test.go`. Model it on the existing `TestCheckoutGatewayStorefrontReadPathsSLIT` in `checkout_slit_test.go` — read that file first and mirror its `testkit` setup, build tag and stub-server shape exactly.
+
+```go
+//go:build slit
+
+package checkout
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/razorpay/1cc-consumer-app/pkg/shopify/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMobileCartGatewayReadSLIT(t *testing.T) {
+	tests := map[string]struct {
+		status      int
+		body        string
+		wantErr     bool
+		wantVariant string
+		wantQty     int64
+	}{
+		"should return mapped variant and quantity then no error": {
+			status: http.StatusOK,
+			body: `{"data":{"cart":{"note":"gift","cost":{"totalAmount":{"amount":"499.00","currencyCode":"INR"}},
+				"lines":{"edges":[{"node":{"quantity":2,"merchandise":{"id":"gid://shopify/ProductVariant/42",
+				"sku":"SKU1","title":"Small","taxable":true,"price":{"amount":"249.50","currencyCode":"INR"},
+				"product":{"id":"gid://shopify/Product/7","title":"Tee","productType":"Apparel"}}}}]}}}}`,
+			wantVariant: "gid://shopify/ProductVariant/42",
+			wantQty:     2,
+		},
+		"should map unauthorized then return authentication error": {
+			status:  http.StatusUnauthorized,
+			body:    `{"errors":["unauthorized"]}`,
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			gw, teardown := newStubbedCheckoutGateway(t, "/api/2023-10/graphql.json", tc.status, tc.body)
+			defer teardown()
+
+			res, err := gw.GetMobileCartDetails(context.Background(),
+				&models.Credentials{ShopName: "teststore", StorefrontAccessToken: "storefront-token"},
+				"gid://shopify/Cart/c1-abc")
+
+			if tc.wantErr {
+				require.NotNil(t, err)
+				return
+			}
+			require.Nil(t, err)
+			require.NotNil(t, res.Data.Cart)
+			line := res.Data.Cart.Lines.Edges[0].Node
+			assert.Equal(t, tc.wantVariant, line.Merchandise.ID)
+			assert.Equal(t, tc.wantQty, line.Quantity)
+		})
+	}
+}
+```
+
+`newStubbedCheckoutGateway` is the helper you extract from the existing SLIT file's setup in the next step.
+
+- [ ] **Step 6: Run the test to verify it fails**
+
+```bash
+cd /Users/n.maneeshgupta/Documents/Codes/1cc-consumer-app
+APP_ENV=slit_local WORKDIR=$(pwd) go test -tags slit ./internal/gateway/shopify/checkout/... -run TestMobileCartGatewayReadSLIT -v
+```
+Expected: FAIL — `gw.GetMobileCartDetails undefined` and `newStubbedCheckoutGateway undefined`.
+
+- [ ] **Step 7: Extract the stub helper**
+
+In `checkout_slit_test.go`, factor the stub-server construction used by `TestCheckoutGatewayStorefrontReadPathsSLIT` into:
+
+```go
+func newStubbedCheckoutGateway(t *testing.T, path string, status int, body string) (interfaces.ICheckoutGateway, func())
+```
+
+Leave the existing tests calling it, so they still pass unchanged. This is the `testData` util-function convention — shared setup behind one factory rather than duplicated per test.
+
+- [ ] **Step 8: Implement the gateway method**
+
+Create `internal/gateway/shopify/checkout/mobilecart.go`. Error mapping mirrors `GetCartByStoreFrontId` (`checkout.go:106-150`) so on-call sees the same classes from both read paths.
+
+```go
+package checkout
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/razorpay/1cc-consumer-app/internal/gateway/shopify/checkout/dtos/response"
+	"github.com/razorpay/1cc-consumer-app/internal/tracecodes"
+	"github.com/razorpay/1cc-consumer-app/pkg/errors/errorclass"
+	"github.com/razorpay/1cc-consumer-app/pkg/errors/errorcodes"
+	"github.com/razorpay/1cc-consumer-app/pkg/logger"
+	"github.com/razorpay/1cc-consumer-app/pkg/shopify/client"
+	shopifyqueries "github.com/razorpay/1cc-consumer-app/pkg/shopify/client/graphql"
+	"github.com/razorpay/1cc-consumer-app/pkg/shopify/models"
+	"github.com/razorpay/goutils/errors"
+)
+
+// GetMobileCartDetails reads the cart the mobile app created under ITS OWN
+// Storefront app. That is why the caller passes the app's storefront token
+// rather than the merchant's: a cart is only readable by the Storefront app
+// that created it. ShopName still comes from merchant config, never the
+// request, so a supplied token cannot point this call at another shop.
+func (c *checkoutGateway) GetMobileCartDetails(
+	ctx context.Context,
+	credentials *models.Credentials,
+	cartID string,
+) (*response.MobileCartResponse, errors.IError) {
+	shopifyClient := client.NewClient(ctx, *credentials, c.client)
+
+	res, statusCode, _, err := shopifyClient.MakeStorefrontRequest(models.GraphQLRequest{
+		Query:     shopifyqueries.GetMobileCartDetailsQuery(),
+		Variables: map[string]interface{}{"cartID": cartID},
+	})
+
+	if statusCode != http.StatusOK {
+		logger.Logger(ctx).WithField("status_code", statusCode).
+			Error(tracecodes.MobileCartFetchFailed)
+		switch statusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return nil, errorclass.AuthenticationError.
+				New(errorcodes.AuthenticationError).
+				Wrap(fmt.Errorf("unauthorized")).Report(ctx)
+		case http.StatusBadRequest:
+			return nil, errorclass.BadRequestError.
+				New(errorcodes.BadRequestError).
+				Wrap(fmt.Errorf("bad request")).Report(ctx)
+		default:
+			return nil, errorclass.GatewayError.
+				New(errorcodes.ShopifyGatewayError).
+				WithInternalMetadata(map[string]string{"status": strconv.Itoa(statusCode)}).
+				Wrap(fmt.Errorf("unknown")).Report(ctx)
+		}
+	}
+	if err != nil {
+		logger.Logger(ctx).WithError(err).Error(tracecodes.MobileCartFetchFailed)
+		return nil, errorclass.GatewayError.
+			New(errorcodes.ShopifyGatewayError).Wrap(err).Report(ctx)
+	}
+
+	var parsed response.MobileCartResponse
+	if uerr := json.Unmarshal(res, &parsed); uerr != nil {
+		return nil, errorclass.InternalServerError.
+			New(errorcodes.JSONUnMarshalError).Wrap(uerr).Report(ctx)
+	}
+	if parsed.Data == nil || parsed.Data.Cart == nil {
+		// A 200 with a null cart means the id is unknown to this Storefront app —
+		// almost always a cart created by a different app, or an expired cart.
+		return nil, errorclass.NotFoundError.
+			New(errorcodes.NotFoundError).
+			Wrap(fmt.Errorf("cart not found")).Report(ctx)
+	}
+	logger.Logger(ctx).Info(tracecodes.MobileCartFetchSuccess)
+	return &parsed, nil
+}
+```
+
+- [ ] **Step 9: Add trace codes**
+
+Find the file in `internal/tracecodes/` that holds the existing `ShopifyCreateCheckoutStep` and `FetchCartDetails` constants and add alongside them:
+
+```go
+	MobileCartFetchSuccess = "MOBILE_CART_FETCH_SUCCESS"
+	MobileCartFetchFailed  = "MOBILE_CART_FETCH_FAILED"
+```
+
+If `errorcodes.NotFoundError` does not exist, use the constant the existing `FetchCart` not-found path uses in `internal/controllers/checkout/checkout.go:217`.
+
+- [ ] **Step 10: Run the test to verify it passes**
+
+```bash
+APP_ENV=slit_local WORKDIR=$(pwd) go test -tags slit ./internal/gateway/shopify/checkout/... -run TestMobileCartGatewayReadSLIT -v
+```
+Expected: PASS, both subtests. Then confirm nothing regressed:
+```bash
+APP_ENV=slit_local WORKDIR=$(pwd) go test -tags slit ./internal/gateway/shopify/checkout/... -v
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add pkg/shopify/client/graphql/queries.go \
+        internal/gateway/shopify/checkout/ \
+        internal/tracecodes/ test/mock/
+git commit -m "feat(checkout): add mobile Storefront cart read for native Magic flow"
+```
+
+---
+
+## Task 2: Storefront cart → `dtos.Cart` mapper
+
+Turn the Storefront read into the `/cart.js`-shaped `dtos.Cart` that `CreateCheckout` already validates and consumes.
+
+Two conversions carry real consequences, so they get their own tests:
+- `gid://shopify/ProductVariant/42` → `int64(42)`. `dtos.Item.VariantId` and `ProductId` are `int64`; Storefront returns global IDs.
+- `gid://shopify/Cart/c1-abc` → `"c1-abc"`. `storeCartTokenToUniqueIDMapping` (`internal/checkout/checkout.go:164`) keys on the token, and it is **service-level**, so the mobile path does hit it — a full gid would corrupt that mapping for every mobile cart.
+
+  > **Correction, verified during execution.** An earlier draft also cited `observeCartProperties`' `strings.HasPrefix(token, "c1-")` check. That function is **controller-only** (`internal/controllers/checkout/checkout.go:89`), and `MobileInit` calls the *service* `CreateCheckout` directly, so it never runs for mobile carts. That is not a defect — the metric exists to detect `/cart.js` schema drift from the web plugin, which cannot happen to a server-built cart. But it is not a justification for the token strip. `storeCartTokenToUniqueIDMapping` is.
+
+**Files:**
+- Create: `internal/checkout/mobiletransformers.go`
+- Test: `internal/checkout/mobiletransformers_test.go`
+
+**Interfaces:**
+- Consumes: `response.MobileCartResponse` (Task 1)
+- Produces:
+  - `func numericIDFromGID(gid string) int64`
+  - `func cartTokenFromGID(gid string) string`
+  - `func toCartDTO(cartID string, sf *response.MobileCart) *dtos.Cart`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/checkout/mobiletransformers_test.go`:
+
+```go
+//go:build unit
+
+package checkout
+
+import (
+	"testing"
+
+	"github.com/razorpay/1cc-consumer-app/internal/gateway/shopify/checkout/dtos/response"
+	"github.com/stretchr/testify/assert"
+)
+
+func strPtr(s string) *string    { return &s }
+func f64Ptr(f float64) *float64  { return &f }
+func boolPtr(b bool) *bool       { return &b }
+
+func TestNumericIDFromGID(t *testing.T) {
+	tests := map[string]struct {
+		gid  string
+		want int64
+	}{
+		"should extract the trailing id then return it":        {"gid://shopify/ProductVariant/42", 42},
+		"should extract a product id then return it":           {"gid://shopify/Product/7", 7},
+		"should return zero when the gid has no numeric tail":  {"gid://shopify/ProductVariant/abc", 0},
+		"should return zero when the gid is empty":             {"", 0},
+	}
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, numericIDFromGID(tc.gid))
+		})
+	}
+}
+
+func TestCartTokenFromGID(t *testing.T) {
+	tests := map[string]struct {
+		gid  string
+		want string
+	}{
+		"should strip the gid prefix then return the bare token": {"gid://shopify/Cart/c1-abc123", "c1-abc123"},
+		"should return the input unchanged when already bare":    {"c1-abc123", "c1-abc123"},
+		"should return empty when the input is empty":            {"", ""},
+	}
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, cartTokenFromGID(tc.gid))
+		})
+	}
+}
+
+func TestToCartDTO(t *testing.T) {
+	sf := &response.MobileCart{
+		Note: strPtr("leave at door"),
+		Cost: &response.MobileCartCost{
+			TotalAmount: &response.MobileMoney{Amount: "499.00", CurrencyCode: "INR"},
+		},
+		Lines: &response.MobileCartLines{Edges: []response.MobileCartLineEdge{{
+			Node: &response.MobileCartLine{
+				Quantity: 2,
+				Merchandise: &response.MobileMerchandise{
+					ID:               "gid://shopify/ProductVariant/42",
+					SKU:              strPtr("SKU1"),
+					Title:            strPtr("Small"),
+					Weight:           f64Ptr(1.5),
+					WeightUnit:       strPtr("KILOGRAMS"),
+					RequiresShipping: boolPtr(true),
+					Taxable:          boolPtr(true),
+					Price:            &response.MobileMoney{Amount: "249.50", CurrencyCode: "INR"},
+					Image:            &response.MobileImage{URL: strPtr("https://cdn/img.png")},
+					Product: &response.MobileProduct{
+						ID:          "gid://shopify/Product/7",
+						Title:       strPtr("Tee"),
+						ProductType: strPtr("Apparel"),
+						Description: strPtr("A tee"),
+					},
+				},
+			},
+		}}},
+	}
+
+	got := toCartDTO("gid://shopify/Cart/c1-abc123", sf)
+
+	t.Run("should strip the cart gid then set a bare c1 token", func(t *testing.T) {
+		assert.Equal(t, "c1-abc123", *got.Token)
+	})
+	t.Run("should convert the major-unit total then store paise", func(t *testing.T) {
+		assert.Equal(t, int64(49900), got.TotalPrice)
+	})
+	t.Run("should carry the currency then set INR", func(t *testing.T) {
+		assert.Equal(t, "INR", got.Currency)
+	})
+	t.Run("should map the variant gid then set a numeric variant id", func(t *testing.T) {
+		assert.Equal(t, int64(42), got.Items[0].VariantId)
+		assert.Equal(t, int64(7), got.Items[0].ProductId)
+	})
+	t.Run("should convert the line price then store paise", func(t *testing.T) {
+		assert.Equal(t, int64(24950), got.Items[0].Price)
+	})
+	t.Run("should convert kilograms then store grams", func(t *testing.T) {
+		assert.Equal(t, int64(1500), got.Items[0].Grams)
+	})
+	t.Run("should carry the descriptive fields then populate them", func(t *testing.T) {
+		assert.Equal(t, "SKU1", got.Items[0].Sku)
+		assert.Equal(t, "Tee", got.Items[0].Title)
+		assert.Equal(t, "Small", got.Items[0].Variant)
+		assert.Equal(t, "Apparel", got.Items[0].ProductType)
+		assert.Equal(t, "https://cdn/img.png", got.Items[0].Image)
+		assert.True(t, got.Items[0].Taxable)
+		assert.True(t, got.Items[0].RequireShipping)
+		assert.Equal(t, int64(2), got.Items[0].Quantity)
+	})
+	t.Run("should tolerate a nil merchandise then skip the line", func(t *testing.T) {
+		partial := &response.MobileCart{
+			Cost:  &response.MobileCartCost{TotalAmount: &response.MobileMoney{Amount: "0.00", CurrencyCode: "INR"}},
+			Lines: &response.MobileCartLines{Edges: []response.MobileCartLineEdge{{Node: &response.MobileCartLine{Quantity: 1}}}},
+		}
+		assert.Len(t, toCartDTO("gid://shopify/Cart/c1-x", partial).Items, 0)
+	})
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /Users/n.maneeshgupta/Documents/Codes/1cc-consumer-app
+go test -tags unit ./internal/checkout/... -run 'TestNumericIDFromGID|TestCartTokenFromGID|TestToCartDTO' -v
+```
+Expected: FAIL — `undefined: numericIDFromGID`.
+
+- [ ] **Step 3: Implement the mapper**
+
+Create `internal/checkout/mobiletransformers.go`:
+
+```go
+package checkout
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/razorpay/1cc-consumer-app/internal/checkout/dtos"
+	"github.com/razorpay/1cc-consumer-app/internal/gateway/shopify/checkout/dtos/response"
+)
+
+// Storefront returns global IDs ("gid://shopify/ProductVariant/42") while
+// dtos.Item carries int64 ids, because the /cart.js shape it mirrors is the
+// REST one. A gid we cannot parse yields 0 rather than an error: MCS reprices
+// from Shopify regardless, so a bad id fails loudly downstream instead of
+// blocking cart construction here.
+func numericIDFromGID(gid string) int64 {
+	idx := strings.LastIndex(gid, "/")
+	if idx < 0 || idx+1 >= len(gid) {
+		return 0
+	}
+	n, err := strconv.ParseInt(gid[idx+1:], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// observeCartProperties and the cart-token->unique-id mapping both key on a
+// bare "c1-" token. Passing the full gid through would silently disable
+// cart-property metrics for every mobile cart, so strip the prefix here.
+func cartTokenFromGID(gid string) string {
+	idx := strings.LastIndex(gid, "/")
+	if idx < 0 || idx+1 >= len(gid) {
+		return gid
+	}
+	return gid[idx+1:]
+}
+
+// Shopify money is a major-unit decimal string; the cart DTO is in the minor
+// unit, matching what /cart.js gives the web plugin.
+func toMinorUnit(amount string) int64 {
+	f, err := strconv.ParseFloat(amount, 64)
+	if err != nil {
+		return 0
+	}
+	return int64(math.Round(f * 100))
+}
+
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func derefBool(b *bool) bool {
+	return b != nil && *b
+}
+
+// PG Router stores weight in grams regardless of the store's Shopify config,
+// which is why CreateOrderAndGetPreferences normalises KILOGRAMS downstream.
+// We normalise at the source so the cart is already consistent.
+func toGrams(weight *float64, unit *string) int64 {
+	if weight == nil {
+		return 0
+	}
+	if unit != nil && *unit == "KILOGRAMS" {
+		return int64(math.Round(*weight * 1000))
+	}
+	return int64(math.Round(*weight))
+}
+
+// toCartDTO converts the Storefront cart read into the /cart.js-shaped cart
+// that CreateCheckout validates. No value here is client-supplied: everything
+// comes from Shopify via the gateway, which is what keeps pricing authority
+// server-side.
+func toCartDTO(cartID string, sf *response.MobileCart) *dtos.Cart {
+	token := cartTokenFromGID(cartID)
+	cart := &dtos.Cart{
+		Token: &token,
+		Items: []dtos.Item{},
+	}
+	if sf == nil {
+		return cart
+	}
+	if sf.Note != nil {
+		cart.Note = *sf.Note
+	}
+	if sf.Cost != nil && sf.Cost.TotalAmount != nil {
+		cart.TotalPrice = toMinorUnit(sf.Cost.TotalAmount.Amount)
+		cart.Currency = sf.Cost.TotalAmount.CurrencyCode
+	}
+	if sf.Lines == nil {
+		return cart
+	}
+	for _, edge := range sf.Lines.Edges {
+		if edge.Node == nil || edge.Node.Merchandise == nil {
+			continue
+		}
+		m := edge.Node.Merchandise
+		item := dtos.Item{
+			VariantId:       numericIDFromGID(m.ID),
+			Quantity:        edge.Node.Quantity,
+			Sku:             derefStr(m.SKU),
+			Variant:         derefStr(m.Title),
+			Taxable:         derefBool(m.Taxable),
+			RequireShipping: derefBool(m.RequiresShipping),
+			Grams:           toGrams(m.Weight, m.WeightUnit),
+		}
+		if m.Price != nil {
+			item.Price = toMinorUnit(m.Price.Amount)
+		}
+		if m.Image != nil {
+			item.Image = derefStr(m.Image.URL)
+		}
+		if m.Product != nil {
+			item.ProductId = numericIDFromGID(m.Product.ID)
+			item.Title = derefStr(m.Product.Title)
+			item.ProductType = derefStr(m.Product.ProductType)
+			item.ProductDescription = derefStr(m.Product.Description)
+		}
+		cart.Items = append(cart.Items, item)
+	}
+	return cart
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+go test -tags unit ./internal/checkout/... -run 'TestNumericIDFromGID|TestCartTokenFromGID|TestToCartDTO' -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/checkout/mobiletransformers.go internal/checkout/mobiletransformers_test.go
+git commit -m "feat(checkout): map Storefront cart to cart DTO for native Magic flow"
+```
+
+---
+
+## Task 3: `MobileInit` service method
+
+Compose the two existing service methods. This is the whole point of the endpoint: `CreateOrderAndGetPreferences` needs only `shopify_checkout_id` + `key_id` and re-reads cart and checkout from the cache `CreateCheckout` wrote (`internal/checkout/checkout.go:555`), so they chain with no new state.
+
+**Files:**
+- Create: `internal/checkout/dtos/mobile.go`
+- Create: `internal/checkout/mobileinit.go`
+- Modify: `internal/checkout/interfaces/interfaces.go`
+- Test: `internal/checkout/mobileinit_test.go`
+
+**Interfaces:**
+- Consumes: `toCartDTO` (Task 2); `ICheckoutGateway.GetMobileCartDetails` (Task 1); existing `s.CreateCheckout`, `s.CreateOrderAndGetPreferences`, `s.merchantConfigService.GetFromCache`, `s.getShopifyCredentialsFromMerchantConfig`
+- Produces: `IService.MobileInit(ctx context.Context, request *dtos.MobileInitRequest) (*checkoutdtos.CreateOrderAndGetPreferencesResponse, errors.IError)`
+
+- [ ] **Step 1: Add the request DTO with service-layer validation**
+
+Create `internal/checkout/dtos/mobile.go`. Validation lives here, not the controller — the service may later be called directly.
+
+```go
+package dtos
+
+import (
+	"context"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/razorpay/1cc-consumer-app/pkg/validations"
+	"github.com/razorpay/goutils/errors"
+)
+
+// MobileInitRequest is the native Magic entry point. CartID is the app's
+// Storefront cart; StorefrontAccessToken is the APP's token, needed because a
+// Storefront cart is only readable by the app that created it. The merchant's
+// own credentials are resolved server-side from MerchantKey and are what
+// create the new checkout.
+type MobileInitRequest struct {
+	Headers               map[string]string
+	MerchantKey           string
+	CartID                string `json:"cart_id"`
+	StorefrontAccessToken string `json:"storefront_access_token"`
+}
+
+func (r MobileInitRequest) Validate(ctx context.Context) errors.IError {
+	return validations.Validate(ctx, &r,
+		validation.Field(&r.MerchantKey, validation.Required),
+		validation.Field(&r.CartID, validation.Required),
+		validation.Field(&r.StorefrontAccessToken, validation.Required),
+	)
+}
+```
+
+- [ ] **Step 2: Add the interface method**
+
+In `internal/checkout/interfaces/interfaces.go`, add to `IService` after `CreateOrderAndGetPreferences`:
+
+```go
+	MobileInit(
+		ctx context.Context,
+		request *dtos.MobileInitRequest,
+	) (*checkoutdtos.CreateOrderAndGetPreferencesResponse, errors.IError)
+```
+
+- [ ] **Step 3: Unbreak the hand-written stub, then regenerate mocks**
+
+`internal/controllers/checkout/checkout_test.go` defines a hand-written `stubCheckoutService` implementing `IService`. Widening the interface makes that whole test package fail to compile, so fix it now — before `make test-unit` in Step 8 trips over it. Add two fields to the struct:
+
+```go
+	mobileInitResult *publicdtos.CreateOrderAndGetPreferencesResponse
+	mobileInitErr    errors.IError
+```
+
+and a method beside the other no-ops:
+
+```go
+func (s *stubCheckoutService) MobileInit(ctx context.Context, req *checkoutreqdtos.MobileInitRequest) (*publicdtos.CreateOrderAndGetPreferencesResponse, errors.IError) {
+	return s.mobileInitResult, s.mobileInitErr
+}
+```
+
+Then:
+
+```bash
+make mock-gen
+go build ./...
+```
+Expected: builds clean. If another type also implements `IService`, the compiler names it — add the method there too.
+
+- [ ] **Step 4: Write the failing test**
+
+Create `internal/checkout/mobileinit_test.go`. Read `internal/checkout/checkout_unit_test.go` first and reuse its suite construction verbatim — do not invent a second way to build the service.
+
+```go
+//go:build unit
+
+package checkout
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/razorpay/1cc-consumer-app/internal/checkout/dtos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMobileInit(t *testing.T) {
+	tests := map[string]struct {
+		req     *dtos.MobileInitRequest
+		prepare func(ts *mobileInitSuite)
+		wantErr bool
+	}{
+		"should chain cart read checkout and order then return the passthrough": {
+			req: validMobileInitRequest(),
+			prepare: func(ts *mobileInitSuite) {
+				ts.expectMerchantConfig()
+				ts.expectCartRead()
+				ts.expectCreateCheckout("chk_1")
+				ts.expectCreateOrder("chk_1", []byte(`{"order_id":"order_1"}`))
+			},
+		},
+		"should reject a blank cart id then not call any gateway": {
+			req:     &dtos.MobileInitRequest{MerchantKey: "rzp_test_x", StorefrontAccessToken: "t"},
+			prepare: func(ts *mobileInitSuite) {},
+			wantErr: true,
+		},
+		"should reject a blank storefront token then not call any gateway": {
+			req:     &dtos.MobileInitRequest{MerchantKey: "rzp_test_x", CartID: "gid://shopify/Cart/c1-a"},
+			prepare: func(ts *mobileInitSuite) {},
+			wantErr: true,
+		},
+		"should stop when the cart read fails then not create a checkout": {
+			req: validMobileInitRequest(),
+			prepare: func(ts *mobileInitSuite) {
+				ts.expectMerchantConfig()
+				ts.expectCartReadError()
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			ts := newMobileInitSuite(t, ctrl)
+			tc.prepare(ts)
+
+			res, err := ts.svc.MobileInit(context.Background(), tc.req)
+
+			if tc.wantErr {
+				require.NotNil(t, err)
+				assert.Nil(t, res)
+				return
+			}
+			require.Nil(t, err)
+			assert.JSONEq(t, `{"order_id":"order_1"}`, string(res.Response))
+		})
+	}
+}
+```
+
+Add the suite to the same file. `NewService`'s eight parameters are fixed by `internal/checkout/checkout.go:57-67`; the only change from `checkoutServiceForUnit` (`checkout_unit_test.go:34`) is swapping the real `mockShopifyGateway()` for the generated `MockICheckoutGateway`, because we need to set an expectation on `GetMobileCartDetails`.
+
+```go
+type mobileInitSuite struct {
+	t              *testing.T
+	svc            *service
+	merchantConfig *merchantconfigmock.MockIService
+	shopifyGateway *shopifycheckoutmock.MockICheckoutGateway
+	mcs            *magiccheckoutservicemock.MockIMagicCheckoutService
+	splitz         *splitzservicemock.MockClient
+}
+
+func newMobileInitSuite(t *testing.T, ctrl *gomock.Controller) *mobileInitSuite {
+	t.Helper()
+	ts := &mobileInitSuite{
+		t:              t,
+		merchantConfig: merchantconfigmock.NewMockIService(ctrl),
+		shopifyGateway: shopifycheckoutmock.NewMockICheckoutGateway(ctrl),
+		mcs:            magiccheckoutservicemock.NewMockIMagicCheckoutService(ctrl),
+		splitz:         splitzservicemock.NewMockClient(ctrl),
+	}
+	svc, err := NewService(
+		ts.merchantConfig,
+		ts.shopifyGateway,
+		mockApiGatewayService(),
+		cache.NewMockCache(),
+		analyticsmock.NewMockIService(ctrl),
+		ts.mcs,
+		ts.splitz,
+		config.Experiments{},
+	)
+	require.NoError(t, err)
+	ts.svc = svc
+	return ts
+}
+
+func validMobileInitRequest() *dtos.MobileInitRequest {
+	return &dtos.MobileInitRequest{
+		MerchantKey:           "rzp_test_x",
+		CartID:                "gid://shopify/Cart/c1-abc",
+		StorefrontAccessToken: "sf-token",
+	}
+}
+
+func (ts *mobileInitSuite) expectMerchantConfig() {
+	shopID, oauth, sfToken := "teststore", "oauth", "merchant-sf-token"
+	apiKey, apiSecret := "k", "s"
+	ts.merchantConfig.EXPECT().
+		GetFromCache(gomock.Any(), gomock.Any()).
+		Return(&merchantconfigdtos.MerchantConfigData{
+			MerchantId:            &TestMerchantId,
+			ShopId:                &shopID,
+			OAuthToken:            &oauth,
+			StorefrontAccessToken: &sfToken,
+			ApiKey:                &apiKey,
+			ApiSecret:             &apiSecret,
+		}, nil).AnyTimes()
+}
+
+func (ts *mobileInitSuite) expectCartRead() {
+	ts.shopifyGateway.EXPECT().
+		GetMobileCartDetails(gomock.Any(), gomock.Any(), "gid://shopify/Cart/c1-abc").
+		DoAndReturn(func(_ context.Context, creds *models.Credentials, _ string) (*gatewayresponse.MobileCartResponse, gerrors.IError) {
+			// The security boundary this endpoint depends on: the shop is
+			// pinned from merchant config, only the token comes from the caller.
+			require.Equal(ts.t, "teststore", creds.ShopName)
+			require.Equal(ts.t, "sf-token", creds.StorefrontAccessToken)
+			return mobileCartFixture(), nil
+		})
+}
+
+func (ts *mobileInitSuite) expectCartReadError() {
+	ts.shopifyGateway.EXPECT().
+		GetMobileCartDetails(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, errorclass.GatewayError.New(errorcodes.ShopifyGatewayError))
+}
+
+func mobileCartFixture() *gatewayresponse.MobileCartResponse {
+	amount := gatewayresponse.MobileMoney{Amount: "499.00", CurrencyCode: "INR"}
+	sku, title := "SKU1", "Small"
+	return &gatewayresponse.MobileCartResponse{
+		Data: &gatewayresponse.MobileCartData{Cart: &gatewayresponse.MobileCart{
+			Cost:  &gatewayresponse.MobileCartCost{TotalAmount: &amount},
+			Lines: &gatewayresponse.MobileCartLines{Edges: []gatewayresponse.MobileCartLineEdge{{
+				Node: &gatewayresponse.MobileCartLine{
+					Quantity: 1,
+					Merchandise: &gatewayresponse.MobileMerchandise{
+						ID:    "gid://shopify/ProductVariant/42",
+						SKU:   &sku,
+						Title: &title,
+						Price: &amount,
+					},
+				},
+			}}},
+		}},
+	}
+}
+```
+
+`expectCreateCheckout(checkoutID string)` and `expectCreateOrder(checkoutID string, passthrough []byte)` set expectations on `ts.mcs` and `ts.splitz`. **Do not invent these** — `internal/checkout/checkout_test.go` already exercises both underlying methods. Copy the expectation setup from its existing `CreateCheckout` test (the one asserting `mockMagicCheckoutService` around line 103) and its `CreateOrderAndGetPreferences` test (the one building `requestMCS := magiccheckoutservice.CreateOrderAndGetPreferencesRequest{...}` around line 221), then wrap each in one of these two helpers. Wrapping rather than copy-pasting per case is the repo's shared-`testData` convention.
+
+Import aliases used above, matching `checkout_unit_test.go`'s existing block plus the gateway mock:
+
+```go
+	shopifycheckoutmock "github.com/razorpay/1cc-consumer-app/test/mock/app/gateway/shopify/checkout"
+	"github.com/razorpay/1cc-consumer-app/pkg/shopify/models"
+```
+
+- [ ] **Step 5: Run the test to verify it fails**
+
+```bash
+go test -tags unit ./internal/checkout/... -run TestMobileInit -v
+```
+Expected: FAIL — `ts.svc.MobileInit undefined`.
+
+- [ ] **Step 6: Implement the service method**
+
+Create `internal/checkout/mobileinit.go`:
+
+```go
+package checkout
+
+import (
+	"context"
+
+	"github.com/razorpay/1cc-consumer-app/internal/checkout/dtos"
+	checkoutdtos "github.com/razorpay/1cc-consumer-app/internal/dtos/checkout"
+	merchantconfigdtos "github.com/razorpay/1cc-consumer-app/internal/merchantconfig/dtos"
+	"github.com/razorpay/1cc-consumer-app/internal/tracecodes"
+	"github.com/razorpay/1cc-consumer-app/pkg/errors/errorclass"
+	"github.com/razorpay/1cc-consumer-app/pkg/errors/errorcodes"
+	"github.com/razorpay/1cc-consumer-app/pkg/logger"
+	"github.com/razorpay/1cc-consumer-app/pkg/shopify/models"
+	"github.com/razorpay/goutils/errors"
+)
+
+const mobileInitSource = "mobile_sdk"
+
+// MobileInit is the native Magic entry point. It exists so a mobile client
+// makes ONE round trip before the modal instead of two: on a mobile network
+// that latency sits directly in the user's tap-to-modal path, and composing
+// here also removes any window in which the cart could drift from the order.
+//
+// It deliberately adds no business logic of its own — CreateCheckout and
+// CreateOrderAndGetPreferences are the same calls the web path makes, so
+// pricing, idempotency and order semantics stay in one place.
+func (s *service) MobileInit(
+	ctx context.Context,
+	request *dtos.MobileInitRequest,
+) (*checkoutdtos.CreateOrderAndGetPreferencesResponse, errors.IError) {
+	if err := request.Validate(ctx); err != nil {
+		logger.Logger(ctx).WithError(err).Error(tracecodes.MobileInitFailed)
+		return nil, err
+	}
+
+	merchantConfig, err := s.merchantConfigService.GetFromCache(ctx,
+		&merchantconfigdtos.GetMerchantConfigRequest{KeyId: request.MerchantKey})
+	if err != nil {
+		logger.Logger(ctx).WithError(err).WithField("reason", "merchant_config").
+			Error(tracecodes.MobileInitFailed)
+		return nil, err
+	}
+	if isCredentialsNil(ctx, merchantConfig, request.MerchantKey) {
+		return nil, errorclass.ShopifyCredentialsNotFound.
+			New(errorcodes.AuthenticationError).Report(ctx)
+	}
+
+	// ShopName is pinned to the merchant's configured shop. Only the token
+	// comes from the request, so a caller cannot aim this read at another
+	// store by supplying someone else's credentials.
+	readCredentials := &models.Credentials{
+		ShopName:              *merchantConfig.ShopId,
+		StorefrontAccessToken: request.StorefrontAccessToken,
+	}
+
+	sfCart, err := s.shopifyCheckoutGateway.GetMobileCartDetails(ctx, readCredentials, request.CartID)
+	if err != nil {
+		logger.Logger(ctx).WithError(err).WithField("reason", "cart_read").
+			Error(tracecodes.MobileInitFailed)
+		return nil, err
+	}
+
+	cart := toCartDTO(request.CartID, sfCart.Data.Cart)
+
+	checkoutRes, err := s.CreateCheckout(ctx, &dtos.CreateCheckoutRequest{
+		Cart:   cart,
+		Key:    &request.MerchantKey,
+		Source: mobileInitSource,
+	})
+	if err != nil {
+		logger.Logger(ctx).WithError(err).WithField("reason", "create_checkout").
+			Error(tracecodes.MobileInitFailed)
+		return nil, err
+	}
+
+	orderRes, err := s.CreateOrderAndGetPreferences(ctx, &dtos.CreateOrderAndGetPreferencesRequest{
+		Headers:     request.Headers,
+		MerchantKey: request.MerchantKey,
+		Body: dtos.CreateOrderAndGetPreferencesRequestBody{
+			ShopifyCheckoutId: checkoutRes.ShopifyCheckoutId,
+			Platform:          mobileInitSource,
+			Source:            mobileInitSource,
+		},
+	})
+	if err != nil {
+		logger.Logger(ctx).WithError(err).WithField("reason", "create_order").
+			Error(tracecodes.MobileInitFailed)
+		return nil, err
+	}
+
+	logger.Logger(ctx).WithField("shopify_checkout_id", checkoutRes.ShopifyCheckoutId).
+		Info(tracecodes.MobileInitSuccess)
+	return orderRes, nil
+}
+```
+
+- [ ] **Step 7: Add trace codes**
+
+Alongside the Task 1 codes:
+
+```go
+	MobileInitSuccess = "MOBILE_INIT_SUCCESS"
+	MobileInitFailed  = "MOBILE_INIT_FAILED"
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+```bash
+go test -tags unit ./internal/checkout/... -run TestMobileInit -v
+make test-unit
+```
+Expected: PASS, all four subtests, and no regressions.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/checkout/ test/mock/
+git commit -m "feat(checkout): add MobileInit composing checkout and order creation"
+```
+
+---
+
+## Task 4: Controller and route
+
+**Files:**
+- Create: `internal/controllers/checkout/mobile.go`
+- Modify: `internal/routing/routercx/v1/checkout.go`
+- Test: `internal/controllers/checkout/mobile_test.go`
+
+**Interfaces:**
+- Consumes: `IService.MobileInit` (Task 3), existing `getMerchantKeyId(ctx)`, `isTestModeAndProdEnv`, `controllerutils.SetModeInContextForTestKeys`
+- Produces: `POST /v1/magic/shopify/init?key_id=<key>` returning the raw preferences passthrough
+
+- [ ] **Step 1: Write the failing controller test**
+
+Create `internal/controllers/checkout/mobile_test.go`, mirroring the structure of the existing `checkout_test.go` in the same package:
+
+```go
+//go:build unit
+
+package checkout
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestMobileInitController(t *testing.T) {
+	tests := map[string]struct {
+		body       string
+		query      string
+		prepare    func(ts *controllerSuite)
+		wantStatus int
+	}{
+		"should return 200 and the passthrough then set json content type": {
+			body:  `{"cart_id":"gid://shopify/Cart/c1-a","storefront_access_token":"t"}`,
+			query: "?key_id=rzp_test_x",
+			prepare: func(ts *controllerSuite) {
+				ts.expectMobileInitSuccess([]byte(`{"order_id":"order_1"}`))
+			},
+			wantStatus: http.StatusOK,
+		},
+		"should return 400 when the body is malformed then not call the service": {
+			body:       `{`,
+			query:      "?key_id=rzp_test_x",
+			prepare:    func(ts *controllerSuite) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		"should return 400 when a test key is used in prod then not call the service": {
+			body:       `{"cart_id":"gid://shopify/Cart/c1-a","storefront_access_token":"t"}`,
+			query:      "?key_id=rzp_test_x",
+			prepare:    func(ts *controllerSuite) { ts.forceProdEnv() },
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			ts := newControllerSuite(t)
+			tc.prepare(ts)
+			rec := ts.postJSON("/v1/magic/shopify/init"+tc.query, tc.body)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("got %d want %d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+```
+
+`stubCheckoutService` already gained its `MobileInit` method and the `mobileInitResult` / `mobileInitErr` fields in Task 3 Step 3. If it did not, go back and do that first — the package will not compile without it.
+
+Add the suite to `mobile_test.go`, following `checkout_test.go`'s existing `httptest` + `gin` pattern:
+
+```go
+type controllerSuite struct {
+	t       *testing.T
+	stub    *stubCheckoutService
+	router  *gin.Engine
+	prevEnv string
+}
+
+func newControllerSuite(t *testing.T) *controllerSuite {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ts := &controllerSuite{t: t, stub: &stubCheckoutService{}, prevEnv: os.Getenv("APP_ENV")}
+	t.Cleanup(func() { os.Setenv("APP_ENV", ts.prevEnv) })
+
+	controller := NewController(ts.stub)
+	ts.router = gin.New()
+	ts.router.POST("/v1/magic/shopify/init", controller.MobileInit)
+	return ts
+}
+
+func (ts *controllerSuite) postJSON(path, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ts.router.ServeHTTP(rec, req)
+	return rec
+}
+
+func (ts *controllerSuite) expectMobileInitSuccess(passthrough []byte) {
+	ts.stub.mobileInitResult = &publicdtos.CreateOrderAndGetPreferencesResponse{Response: passthrough}
+}
+
+// isTestModeAndProdEnv reads the environment, so the prod guard is only
+// exercisable by setting it. Cleanup restores it.
+func (ts *controllerSuite) forceProdEnv() {
+	os.Setenv("APP_ENV", "prod")
+}
+```
+
+If `common.GetEnv()` reads a different variable than `APP_ENV`, set that one instead — check `internal/common` before assuming.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+go test -tags unit ./internal/controllers/checkout/... -run TestMobileInitController -v
+```
+Expected: FAIL — route not registered / handler undefined.
+
+- [ ] **Step 3: Implement the controller**
+
+Create `internal/controllers/checkout/mobile.go`. It does transport parsing only; every semantic check lives in `MobileInitRequest.Validate`.
+
+```go
+package checkout
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	checkoutrequest "github.com/razorpay/1cc-consumer-app/internal/checkout/dtos"
+	controllerutils "github.com/razorpay/1cc-consumer-app/internal/controllers/utils"
+	"github.com/razorpay/1cc-consumer-app/internal/tracecodes"
+	"github.com/razorpay/1cc-consumer-app/pkg/errors/errorclass"
+	"github.com/razorpay/1cc-consumer-app/pkg/errors/errorcodes"
+	"github.com/razorpay/1cc-consumer-app/pkg/logger"
+)
+
+// MobileInit backs POST /v1/magic/shopify/init — the single call a mobile SDK
+// makes before opening the Magic modal. The response is the preferences
+// passthrough, byte-identical to CreateOrderAndGetPreferences, so the client
+// reads order_id and experiments from it exactly as the web plugin does.
+func (c *Checkout) MobileInit(ctx *gin.Context) {
+	body := checkoutrequest.MobileInitRequest{}
+	if err := ctx.ShouldBindJSON(&body); err != nil {
+		logger.Logger(ctx).WithError(err).Error(tracecodes.MobileInitFailed)
+		ctx.AbortWithStatusJSON(http.StatusBadRequest,
+			errorclass.BadRequestError.New(errorcodes.BadRequestError).Public())
+		return
+	}
+
+	merchantKey := strings.TrimSpace(getMerchantKeyId(ctx))
+	if isTestModeAndProdEnv(merchantKey) {
+		logger.Logger(ctx).WithField("reason", "test_key_being_used").
+			Error(tracecodes.MobileInitFailed)
+		ctx.AbortWithStatusJSON(http.StatusBadRequest,
+			errorclass.BadRequestError.New(errorcodes.BadRequestError).
+				WithPublicMetadata(map[string]string{"message": "test_key_being_used"}).Public())
+		return
+	}
+	controllerutils.SetModeInContextForTestKeys(ctx, merchantKey)
+
+	headers := make(map[string]string)
+	for name, values := range ctx.Request.Header {
+		for _, value := range values {
+			headers[name] = value
+		}
+	}
+	body.Headers = headers
+	body.MerchantKey = merchantKey
+
+	res, err := c.checkoutService.MobileInit(ctx, &body)
+	if err != nil {
+		// ORDER IS LOAD-BEARING: check the most specific class first.
+		// errorclass parents chain, and class.Is() walks up that chain — so
+		// NotFoundError, whose parent is BadRequestError, is swallowed by a
+		// BadRequestError check placed above it. The sibling controllers get
+		// this right at checkout.go:217 and :242; match them.
+		if err.Is(errorclass.NotFoundError) {
+			ctx.AbortWithStatusJSON(http.StatusNotFound, err.Public())
+		} else if err.Is(errorclass.UnprocessableEntityError) {
+			// CreateCheckout returns this for invalid or out-of-stock Shopify
+			// variants (checkout.go:437-442) — an expected shopper-facing
+			// condition, not a server fault. Reporting it as 500 buries a real
+			// merchant case in on-call noise.
+			ctx.AbortWithStatusJSON(http.StatusUnprocessableEntity, err.Public())
+		} else if err.Is(errorclass.ShopifyCredentialsNotFound) || err.Is(errorclass.AuthenticationError) {
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, err.Public())
+		} else if err.Is(errorclass.BadRequestError) || err.Is(errorclass.BadRequestValidationError) {
+			ctx.AbortWithStatusJSON(http.StatusBadRequest, err.Public())
+		} else if err.Is(errorclass.GatewayError) || err.Is(errorclass.ShopifyThrottledError) {
+			ctx.AbortWithStatusJSON(http.StatusServiceUnavailable, err.Public())
+		} else {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, err.Public())
+		}
+		return
+	}
+
+	ctx.Data(http.StatusOK, "application/json", res.Response)
+}
+```
+
+- [ ] **Step 4: Register the route**
+
+In `internal/routing/routercx/v1/checkout.go`, add inside the existing block:
+
+```go
+		routerGroup.POST("/shopify/init", controller.MobileInit)
+```
+
+The group is mounted at `/v1/magic` (`internal/routing/routercx/router.go:42`), giving `POST /v1/magic/shopify/init` — the path `checkout.js` already calls at `initialize-shopify.ts:226`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+go test -tags unit ./internal/controllers/checkout/... -run TestMobileInitController -v
+make test-unit
+```
+Expected: PASS.
+
+- [ ] **Step 6: Verify the route manually**
+
+```bash
+grep -n "shopify/init" internal/routing/routercx/v1/checkout.go
+```
+Expected: one match registering `controller.MobileInit`.
+
+- [ ] **Step 7: Commit and open the PR**
+
+```bash
+git add internal/controllers/checkout/ internal/routing/routercx/v1/checkout.go
+git commit -m "feat(checkout): expose POST /v1/magic/shopify/init for native Magic"
+```
+
+Before opening the PR, run the fresh-context pre-PR self-critic pass (lens G in `.agents/skills/code-review/SKILL.md`) over your own diff, and apply any `status: active` entries in `.slash/reviewer-memory/learnings.yaml` whose `path_glob` matches the files you touched.
+
+---
+
+# Repo B — `react-native-razorpay`
+
+Work from `/Users/n.maneeshgupta/Documents/Codes/react-native-razorpay` on a feature branch off `master`.
+
+## Task 5: Test infrastructure
+
+The repo has no test tooling — no jest, no devDependencies, no tests. Everything downstream depends on this.
+
+**Files:**
+- Create: `babel.config.js`, `jest.config.js`, `__mocks__/react-native.js`, `__tests__/helpers/suite.js`, `__tests__/infra.test.js`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `makeSuite()` returning `{ RN, RazorpayCheckout, emitter, native }`; `EVENTS = { success, error, wallet }`; `npm test` runs Jest
+
+- [ ] **Step 1: Add dev dependencies and the test script**
+
+Edit `package.json`, keeping every existing key:
+
+```json
+  "scripts": {
+    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.0",
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-typescript": "^7.24.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
+  }
+```
+
+Then `npm install`.
+
+- [ ] **Step 2: Create `babel.config.js`**
+
+```js
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    '@babel/preset-typescript',
+  ],
+};
+```
+
+- [ ] **Step 3: Create `jest.config.js`**
+
+```js
+module.exports = {
+  testEnvironment: 'node',
+  moduleFileExtensions: ['js', 'ts', 'json'],
+  testMatch: ['**/__tests__/**/*.test.js'],
+  moduleNameMapper: {
+    '^react-native$': '<rootDir>/__mocks__/react-native.js',
+  },
+  clearMocks: true,
+};
+```
+
+- [ ] **Step 4: Create `__mocks__/react-native.js`**
+
+We mock `react-native` wholesale rather than pulling its Jest preset — the package imports only `NativeModules` and `NativeEventEmitter`, so this keeps the toolchain small and the tests fast.
+
+```js
+class NativeEventEmitter {
+  constructor(nativeModule) {
+    this.nativeModule = nativeModule;
+    this.listeners = {};
+    NativeEventEmitter.instances.push(this);
+  }
+
+  addListener(event, cb) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(cb);
+    return { remove: () => this.removeListener(event, cb) };
+  }
+
+  removeListener(event, cb) {
+    this.listeners[event] = (this.listeners[event] || []).filter((f) => f !== cb);
+  }
+
+  removeAllListeners(event) {
+    this.listeners[event] = [];
+  }
+
+  emit(event, data) {
+    (this.listeners[event] || []).slice().forEach((cb) => cb(data));
+  }
+
+  listenerCount(event) {
+    return (this.listeners[event] || []).length;
+  }
+}
+
+NativeEventEmitter.instances = [];
+
+const NativeModules = {
+  RNRazorpayCheckout: { open: jest.fn() },
+  RazorpayEventEmitter: { addListener: jest.fn(), removeListeners: jest.fn() },
+};
+
+module.exports = { NativeModules, NativeEventEmitter };
+```
+
+- [ ] **Step 5: Create `__tests__/helpers/suite.js`**
+
+One factory so adding a dependency later does not force edits across every test.
+
+```js
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+// Each suite loads the SDK fresh. RazorpayCheckout.js builds a module-scoped
+// NativeEventEmitter at import time, so without resetModules one test's
+// listeners leak into the next and failures look like ordering flakes.
+// resetModules also gives a fresh react-native mock, so `instances` starts
+// empty and the last entry is always this suite's emitter.
+function makeSuite() {
+  jest.resetModules();
+  const RN = require('react-native');
+  const RazorpayCheckout = require(path.join(ROOT, 'RazorpayCheckout.js')).default;
+  const emitter = RN.NativeEventEmitter.instances[RN.NativeEventEmitter.instances.length - 1];
+  return { RN, RazorpayCheckout, emitter, native: RN.NativeModules.RNRazorpayCheckout };
+}
+
+const EVENTS = {
+  success: 'Razorpay::PAYMENT_SUCCESS',
+  error: 'Razorpay::PAYMENT_ERROR',
+  wallet: 'Razorpay::EXTERNAL_WALLET_SELECTED',
+};
+
+module.exports = { makeSuite, EVENTS };
+```
+
+- [ ] **Step 6: Write the infrastructure test**
+
+Create `__tests__/infra.test.js`:
+
+```js
+const { makeSuite, EVENTS } = require('./helpers/suite');
+
+describe('test infrastructure', () => {
+  const cases = {
+    'should load the SDK then expose open': (ts) => {
+      expect(typeof ts.RazorpayCheckout.open).toBe('function');
+    },
+    'should build an event emitter then expose emit': (ts) => {
+      expect(typeof ts.emitter.emit).toBe('function');
+    },
+    'should reach the native module then expose open': (ts) => {
+      expect(typeof ts.native.open).toBe('function');
+    },
+    'should register a success listener then count one': (ts) => {
+      ts.emitter.addListener(EVENTS.success, () => {});
+      expect(ts.emitter.listenerCount(EVENTS.success)).toBe(1);
+    },
+  };
+
+  Object.entries(cases).forEach(([name, assertion]) => {
+    it(name, () => assertion(makeSuite()));
+  });
+});
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+npm test -- __tests__/infra.test.js
+```
+Expected: PASS, 4 tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add package.json babel.config.js jest.config.js __mocks__ __tests__
+git commit -m "chore: add jest test infrastructure"
+```
+
+`package-lock.json` is **not** staged — this repo's `.gitignore` carries `*-lock.json`. Do not force-add it. `yarn.lock` is the tracked lock file here.
+
+---
+
+## Task 6: Characterisation tests for `open()`
+
+Lock the current behaviour — quirks included — **before** Task 7 refactors it. These tests are the contract that proves `open()` is unchanged.
+
+**Files:**
+- Create: `__tests__/open.regression.test.js`
+
+**Interfaces:**
+- Consumes: `makeSuite()`, `EVENTS` (Task 5)
+- Produces: nothing — this is a safety net for Task 7
+
+- [ ] **Step 1: Write the characterisation tests**
+
+Create `__tests__/open.regression.test.js`:
+
+```js
+const { makeSuite, EVENTS } = require('./helpers/suite');
+
+describe('open() behaviour is frozen', () => {
+  it('should call the native module then pass options through untouched', () => {
+    const ts = makeSuite();
+    const options = { key: 'rzp_test_1', amount: '100', nested: { a: [1, 2] } };
+    ts.RazorpayCheckout.open(options);
+    expect(ts.native.open).toHaveBeenCalledWith(options);
+  });
+
+  it('should resolve the promise then return the success payload', async () => {
+    const ts = makeSuite();
+    const promise = ts.RazorpayCheckout.open({ key: 'k' });
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_1' });
+    await expect(promise).resolves.toEqual({ razorpay_payment_id: 'pay_1' });
+  });
+
+  it('should reject the promise then return the error payload', async () => {
+    const ts = makeSuite();
+    const promise = ts.RazorpayCheckout.open({ key: 'k' });
+    ts.emitter.emit(EVENTS.error, { code: 0, description: 'cancelled' });
+    await expect(promise).rejects.toEqual({ code: 0, description: 'cancelled' });
+  });
+
+  it('should prefer successCallback then never resolve the promise', async () => {
+    const ts = makeSuite();
+    const onSuccess = jest.fn();
+    let settled = false;
+    ts.RazorpayCheckout.open({ key: 'k' }, onSuccess).then(() => { settled = true; });
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_1' });
+    await Promise.resolve();
+    expect(onSuccess).toHaveBeenCalledWith({ razorpay_payment_id: 'pay_1' });
+    expect(settled).toBe(false);
+  });
+
+  it('should prefer errorCallback then never reject the promise', async () => {
+    const ts = makeSuite();
+    const onError = jest.fn();
+    const promise = ts.RazorpayCheckout.open({ key: 'k' }, undefined, onError);
+    promise.catch(() => { throw new Error('promise must not reject'); });
+    ts.emitter.emit(EVENTS.error, { code: 2 });
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledWith({ code: 2 });
+  });
+
+  // QUIRK, DELIBERATELY LOCKED: teardown is global, not per-call. Anything that
+  // "fixes" this changes shipped behaviour for every existing integration.
+  it('should remove every listener on first success then leave zero registered', () => {
+    const ts = makeSuite();
+    ts.RazorpayCheckout.open({ key: 'k' });
+    ts.RazorpayCheckout.onExternalWalletSelection(() => {});
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_1' });
+    expect(ts.emitter.listenerCount(EVENTS.success)).toBe(0);
+    expect(ts.emitter.listenerCount(EVENTS.error)).toBe(0);
+    expect(ts.emitter.listenerCount(EVENTS.wallet)).toBe(0);
+  });
+
+  // QUIRK, DELIBERATELY LOCKED: the wallet callback also tears down the payment
+  // listeners, so a wallet selection can orphan an in-flight open().
+  it('should remove payment listeners on wallet selection then leave zero registered', () => {
+    const ts = makeSuite();
+    ts.RazorpayCheckout.open({ key: 'k' });
+    ts.RazorpayCheckout.onExternalWalletSelection(() => {});
+    ts.emitter.emit(EVENTS.wallet, { external_wallet: 'paytm' });
+    expect(ts.emitter.listenerCount(EVENTS.success)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they pass against current code**
+
+```bash
+npm test -- __tests__/open.regression.test.js
+```
+Expected: PASS, 7 tests. They must pass **before** any refactor — that is what makes them characterisation tests. If any fails, the assertion is wrong about today's behaviour; fix the test, not `RazorpayCheckout.js`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/open.regression.test.js
+git commit -m "test: characterise open() behaviour before refactor"
+```
+
+---
+
+## Task 7: Extract the checkout session helper
+
+`open()` tears down listeners on first success (`RazorpayCheckout.js:45`) using `removeAllListeners`, so nothing can run after it. Phase 3 needs a session that survives success. Extract the wiring; leave `open()`'s behaviour identical.
+
+**HUMAN CHECKPOINT.** Stop after this task and get a review before continuing. This is the only task that touches shipped behaviour.
+
+**Files:**
+- Create: `src/internal/checkoutSession.js`
+- Modify: `RazorpayCheckout.js`
+
+**Interfaces:**
+- Consumes: `NativeModules`, `NativeEventEmitter` from `react-native`
+- Produces:
+  - `EVENT_NAMES = { SUCCESS, ERROR, EXTERNAL_WALLET }`
+  - `getEmitter()` → the shared `NativeEventEmitter`
+  - `removeSubscriptions()` → void
+  - `getNativeModule()` → the resolved native module
+  - `runCheckout(options, { onSuccess, onError, teardown })` → void
+
+- [ ] **Step 1: Create the helper**
+
+Create `src/internal/checkoutSession.js`. Move the architecture detection here verbatim from `RazorpayCheckout.js:5-31`.
+
+```js
+'use strict';
+
+import { NativeModules, NativeEventEmitter } from 'react-native';
+
+// Runtime detection for new architecture.
+// RN <0.74 uses __turboModuleProxy; RN >=0.74 (bridgeless) exposes TurboModuleRegistry and nativeFabricUIManager instead.
+const isTurboModuleEnabled =
+  global.__turboModuleProxy != null ||
+  global.TurboModuleRegistry != null ||
+  global.nativeFabricUIManager != null;
+
+let RazorpayCheckoutModule;
+let RazorpayEventEmitterModule;
+
+if (isTurboModuleEnabled) {
+  try {
+    RazorpayCheckoutModule = require('../NativeRazorpayCheckout').default;
+    RazorpayEventEmitterModule = require('../NativeRazorpayEventEmitter').default;
+  } catch (error) {
+    RazorpayCheckoutModule = NativeModules.RNRazorpayCheckout;
+    RazorpayEventEmitterModule = NativeModules.RazorpayEventEmitter;
+  }
+} else {
+  RazorpayCheckoutModule = NativeModules.RNRazorpayCheckout;
+  RazorpayEventEmitterModule = NativeModules.RazorpayEventEmitter;
+}
+
+const razorpayEvents = new NativeEventEmitter(RazorpayEventEmitterModule);
+
+export const EVENT_NAMES = {
+  SUCCESS: 'Razorpay::PAYMENT_SUCCESS',
+  ERROR: 'Razorpay::PAYMENT_ERROR',
+  EXTERNAL_WALLET: 'Razorpay::EXTERNAL_WALLET_SELECTED',
+};
+
+export function getEmitter() {
+  return razorpayEvents;
+}
+
+export function getNativeModule() {
+  return RazorpayCheckoutModule;
+}
+
+export function removeSubscriptions() {
+  razorpayEvents.removeAllListeners(EVENT_NAMES.SUCCESS);
+  razorpayEvents.removeAllListeners(EVENT_NAMES.ERROR);
+  razorpayEvents.removeAllListeners(EVENT_NAMES.EXTERNAL_WALLET);
+}
+
+// Wires the two payment listeners and launches the native checkout.
+//
+// `teardown` is a parameter rather than a hardcoded removeSubscriptions()
+// because Magic must keep listening past the first success: it still has a
+// Shopify order to place. open() passes the original teardown and so keeps
+// its shipped behaviour exactly.
+export function runCheckout(options, { onSuccess, onError, teardown }) {
+  razorpayEvents.addListener(EVENT_NAMES.SUCCESS, (data) => {
+    onSuccess(data);
+    teardown();
+  });
+  razorpayEvents.addListener(EVENT_NAMES.ERROR, (data) => {
+    onError(data);
+    teardown();
+  });
+  RazorpayCheckoutModule.open(options);
+}
+```
+
+- [ ] **Step 2: Rewrite `RazorpayCheckout.js` to delegate**
+
+Replace the whole file:
+
+```js
+'use strict';
+
+import {
+  EVENT_NAMES,
+  getEmitter,
+  removeSubscriptions,
+  runCheckout,
+} from './src/internal/checkoutSession';
+
+class RazorpayCheckout {
+  static open(options, successCallback, errorCallback) {
+    return new Promise(function (resolve, reject) {
+      runCheckout(options, {
+        onSuccess: (data) => (successCallback || resolve)(data),
+        onError: (data) => (errorCallback || reject)(data),
+        teardown: removeSubscriptions,
+      });
+    });
+  }
+
+  static onExternalWalletSelection(externalWalletCallback) {
+    getEmitter().addListener(EVENT_NAMES.EXTERNAL_WALLET, (data) => {
+      externalWalletCallback(data);
+      removeSubscriptions();
+    });
+  }
+}
+
+export default RazorpayCheckout;
+```
+
+- [ ] **Step 3: Run the characterisation tests**
+
+```bash
+npm test
+```
+Expected: PASS, all 11 tests, **with no test edits.** If any Task 6 test fails, the refactor changed behaviour — revert and retry. Do not adjust the test to match.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add RazorpayCheckout.js src/internal/checkoutSession.js
+git commit -m "refactor: extract checkout session wiring, open() behaviour unchanged"
+```
+
+- [ ] **Step 5: STOP — human review**
+
+Post the diff and the green test run. Do not start Task 8 until a human approves.
+
+---
+
+## Task 8: Error taxonomy
+
+**Files:**
+- Create: `src/magic/core/errors.js`
+- Test: `src/magic/core/__tests__/errors.test.js`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces:
+  - `MAGIC_ERROR_CODES = { ORDER_CREATE_FAILED, CHECKOUT_CANCELLED, PAYMENT_FAILED, COMPLETE_FAILED, INVALID_OPTIONS }`
+  - `class MagicCheckoutError extends Error` with `{ code, reason, details }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/magic/core/__tests__/errors.test.js`:
+
+```js
+const { MagicCheckoutError, MAGIC_ERROR_CODES } = require('../errors');
+
+describe('MagicCheckoutError', () => {
+  it('should build an error then expose code reason and details', () => {
+    const err = new MagicCheckoutError(MAGIC_ERROR_CODES.ORDER_CREATE_FAILED, 'network', {
+      status: 0,
+    });
+    expect(err.code).toBe('MAGIC_ORDER_CREATE_FAILED');
+    expect(err.reason).toBe('network');
+    expect(err.details).toEqual({ status: 0 });
+  });
+
+  it('should extend Error then remain instanceof Error', () => {
+    const err = new MagicCheckoutError(MAGIC_ERROR_CODES.PAYMENT_FAILED, 'user_cancelled');
+    expect(err instanceof Error).toBe(true);
+    expect(err.name).toBe('MagicCheckoutError');
+  });
+
+  it('should default details then return an empty object', () => {
+    expect(new MagicCheckoutError(MAGIC_ERROR_CODES.INVALID_OPTIONS, 'missing_key').details).toEqual({});
+  });
+
+  it('should expose every documented code then match the taxonomy', () => {
+    expect(MAGIC_ERROR_CODES).toEqual({
+      ORDER_CREATE_FAILED: 'MAGIC_ORDER_CREATE_FAILED',
+      CHECKOUT_CANCELLED: 'MAGIC_CHECKOUT_CANCELLED',
+      PAYMENT_FAILED: 'MAGIC_PAYMENT_FAILED',
+      COMPLETE_FAILED: 'MAGIC_COMPLETE_FAILED',
+      INVALID_OPTIONS: 'MAGIC_INVALID_OPTIONS',
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npm test -- src/magic/core/__tests__/errors.test.js
+```
+Expected: FAIL — cannot find module `../errors`.
+
+- [ ] **Step 3: Implement**
+
+Create `src/magic/core/errors.js`:
+
+```js
+'use strict';
+
+// ACTION_STATUS names. The specific cause goes in `reason`, never in the code,
+// so one Coralogix query over MAGIC_* yields success-vs-failure counts split by
+// reason instead of exploding into a code per failure mode.
+export const MAGIC_ERROR_CODES = {
+  ORDER_CREATE_FAILED: 'MAGIC_ORDER_CREATE_FAILED',
+  CHECKOUT_CANCELLED: 'MAGIC_CHECKOUT_CANCELLED',
+  PAYMENT_FAILED: 'MAGIC_PAYMENT_FAILED',
+  COMPLETE_FAILED: 'MAGIC_COMPLETE_FAILED',
+  INVALID_OPTIONS: 'MAGIC_INVALID_OPTIONS',
+};
+
+export class MagicCheckoutError extends Error {
+  constructor(code, reason, details) {
+    super(`${code}: ${reason}`);
+    this.name = 'MagicCheckoutError';
+    this.code = code;
+    this.reason = reason;
+    this.details = details || {};
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npm test -- src/magic/core/__tests__/errors.test.js
+```
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/magic/core/errors.js src/magic/core/__tests__/errors.test.js
+git commit -m "feat(magic): add error taxonomy"
+```
+
+---
+
+## Task 9: Endpoints and the core purity guard
+
+The complete-route choice mirrors `magic-plugins` exactly (`post-checkout.ts:162-166`): branch on an experiment the **server** handed us, never on a hardcoded constant. That is what keeps the choice tunable without an app-store release.
+
+**Files:**
+- Create: `src/magic/core/endpoints.js`
+- Test: `src/magic/core/__tests__/endpoints.test.js`
+- Test: `src/magic/core/__tests__/purity.test.js`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces:
+  - `BASE_URL = 'https://api.razorpay.com/v1'`
+  - `initUrl(key)` → string
+  - `completeUrl(key, experiments)` → string
+  - `POLL_BUDGET_MS`, `BACKOFF_INITIAL_MS`, `BACKOFF_CAP_MS`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/magic/core/__tests__/endpoints.test.js`:
+
+```js
+const { initUrl, completeUrl, BASE_URL } = require('../endpoints');
+
+describe('endpoints', () => {
+  it('should build the init url then include the encoded key', () => {
+    expect(initUrl('rzp_test_a b')).toBe(`${BASE_URL}/magic/shopify/init?key_id=rzp_test_a%20b`);
+  });
+
+  const completeCases = {
+    'should use the monolith route then return 1cc path when the experiment is absent': [
+      undefined,
+      `${BASE_URL}/1cc/shopify/complete?key_id=k`,
+    ],
+    'should use the monolith route then return 1cc path when the variant is off': [
+      { shopify_pre_payment_guardrail: 'variant_off' },
+      `${BASE_URL}/1cc/shopify/complete?key_id=k`,
+    ],
+    'should use the MCS route then return checkouts path when the variant is on': [
+      { shopify_pre_payment_guardrail: 'variant_on' },
+      `${BASE_URL}/checkouts/shopify/complete?key_id=k`,
+    ],
+  };
+
+  Object.entries(completeCases).forEach(([name, [experiments, expected]]) => {
+    it(name, () => expect(completeUrl('k', experiments)).toBe(expected));
+  });
+});
+```
+
+Create `src/magic/core/__tests__/purity.test.js`. This enforces the constraint that makes a Flutter or Capacitor adapter possible later — the core must never reach the bridge directly.
+
+```js
+const fs = require('fs');
+const path = require('path');
+
+const CORE = path.resolve(__dirname, '..');
+
+function coreSourceFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === '__tests__') return [];
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return coreSourceFiles(full);
+    return entry.name.endsWith('.js') ? [full] : [];
+  });
+}
+
+describe('core purity', () => {
+  it('should keep the core platform-neutral then import no react-native', () => {
+    const offenders = coreSourceFiles(CORE).filter((file) =>
+      /from\s+['"]react-native['"]|require\(['"]react-native['"]\)/.test(
+        fs.readFileSync(file, 'utf8')
+      )
+    );
+    expect(offenders).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npm test -- src/magic/core/__tests__/endpoints.test.js
+```
+Expected: FAIL — cannot find module `../endpoints`.
+
+- [ ] **Step 3: Implement**
+
+Create `src/magic/core/endpoints.js`:
+
+```js
+'use strict';
+
+export const BASE_URL = 'https://api.razorpay.com/v1';
+
+// The SDK's own waiting budget for phase 3 — not a money timeout. Exhausting it
+// does NOT mean the order failed: MCS's worker keeps retrying for ~15 minutes
+// after it has the request. Kept short deliberately so the native SDK is never
+// left waiting on the WebView completion callback.
+export const POLL_BUDGET_MS = 8000;
+export const BACKOFF_INITIAL_MS = 500;
+export const BACKOFF_CAP_MS = 2000;
+
+const PRE_PAYMENT_GUARDRAIL = 'shopify_pre_payment_guardrail';
+
+export function initUrl(key) {
+  return `${BASE_URL}/magic/shopify/init?key_id=${encodeURIComponent(key)}`;
+}
+
+// Mirrors magic-plugins post-checkout.ts:162-166. The experiment value arrives
+// in the phase-1 response, so which endpoint a shipped binary calls stays
+// server-tunable — a merchant moved into the variant cohort does not need an
+// app update to keep placing orders.
+export function completeUrl(key, experiments) {
+  const path =
+    experiments && experiments[PRE_PAYMENT_GUARDRAIL] === 'variant_on'
+      ? 'checkouts/shopify/complete'
+      : '1cc/shopify/complete';
+  return `${BASE_URL}/${path}?key_id=${encodeURIComponent(key)}`;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+npm test -- src/magic/core/__tests__/
+```
+Expected: PASS — 4 endpoint tests and 1 purity test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/magic/core/endpoints.js src/magic/core/__tests__/
+git commit -m "feat(magic): add endpoint resolution and core purity guard"
+```
+
+---
+
+## Task 10: HTTP client
+
+Two calls, and the classification of phase-3 outcomes. "Pending" is a **success** path, exactly as it is on web: once MCS has the request, placement is owned by its mutex, 24h marker and SQS worker.
+
+**Files:**
+- Create: `src/magic/core/client.js`
+- Test: `src/magic/core/__tests__/client.test.js`
+
+**Interfaces:**
+- Consumes: `initUrl`, `completeUrl`, `POLL_BUDGET_MS`, `BACKOFF_INITIAL_MS`, `BACKOFF_CAP_MS` (Task 9); `MagicCheckoutError`, `MAGIC_ERROR_CODES` (Task 8)
+- Produces:
+  - `createClient(http)` → `{ init(key, body), complete(key, experiments, handle, now) }`
+  - `init` resolves `{ order_id, experiments }`
+  - `complete` resolves `{ status: 'placed'|'pending', data }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/magic/core/__tests__/client.test.js`:
+
+```js
+const { createClient } = require('../client');
+const { MAGIC_ERROR_CODES } = require('../errors');
+
+function makeHttp(responses) {
+  const calls = [];
+  const queue = responses.slice();
+  return {
+    calls,
+    post: jest.fn((url, body) => {
+      calls.push({ url, body });
+      const next = queue.shift();
+      if (next instanceof Error) return Promise.reject(next);
+      return Promise.resolve(next);
+    }),
+  };
+}
+
+describe('init', () => {
+  it('should post the cart id and token then return order id and experiments', async () => {
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1', experiments: { a: 'b' } } },
+    ]);
+    const res = await createClient(http).init('k', {
+      cart_id: 'gid://shopify/Cart/c1-a',
+      storefront_access_token: 't',
+    });
+    expect(res).toEqual({ order_id: 'order_1', experiments: { a: 'b' } });
+    expect(http.calls[0].url).toContain('/magic/shopify/init?key_id=k');
+    expect(http.calls[0].body).toEqual({
+      cart_id: 'gid://shopify/Cart/c1-a',
+      storefront_access_token: 't',
+    });
+  });
+
+  it('should reject with ORDER_CREATE_FAILED then set reason http_400 on a 4xx', async () => {
+    const http = makeHttp([{ status: 400, data: { error: 'bad' } }]);
+    await expect(createClient(http).init('k', {})).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.ORDER_CREATE_FAILED,
+      reason: 'http_400',
+    });
+  });
+
+  it('should reject with ORDER_CREATE_FAILED then set reason network on a transport error', async () => {
+    const http = makeHttp([new Error('offline')]);
+    await expect(createClient(http).init('k', {})).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.ORDER_CREATE_FAILED,
+      reason: 'network',
+    });
+  });
+
+  it('should reject with ORDER_CREATE_FAILED then set reason missing_order_id when absent', async () => {
+    const http = makeHttp([{ status: 200, data: { experiments: {} } }]);
+    await expect(createClient(http).init('k', {})).rejects.toMatchObject({
+      reason: 'missing_order_id',
+    });
+  });
+});
+
+describe('complete', () => {
+  const handle = {
+    razorpay_order_id: 'order_1',
+    razorpay_payment_id: 'pay_1',
+    razorpay_signature: 'sig',
+    key: 'k',
+  };
+
+  it('should post the handle then return placed on 200', async () => {
+    const http = makeHttp([{ status: 200, data: { order_id: 'shop_1' } }]);
+    const res = await createClient(http).complete('k', undefined, handle, () => 0);
+    expect(res.status).toBe('placed');
+    expect(http.calls[0].body).toEqual(handle);
+  });
+
+  it('should treat a 422 already placed then return pending', async () => {
+    const http = makeHttp([{ status: 422, data: { error: { code: 'ALREADY_PLACED' } } }]);
+    const res = await createClient(http).complete('k', undefined, handle, () => 0);
+    expect(res.status).toBe('pending');
+  });
+
+  it('should retry a 5xx then return placed when the retry succeeds', async () => {
+    const http = makeHttp([
+      { status: 500, data: {} },
+      { status: 200, data: { order_id: 'shop_1' } },
+    ]);
+    let clock = 0;
+    const res = await createClient(http).complete('k', undefined, handle, () => (clock += 100));
+    expect(res.status).toBe('placed');
+    expect(http.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('should exhaust the budget then return pending without throwing', async () => {
+    const http = makeHttp([
+      { status: 500, data: {} },
+      { status: 500, data: {} },
+      { status: 500, data: {} },
+    ]);
+    let clock = 0;
+    const res = await createClient(http).complete('k', undefined, handle, () => (clock += 5000));
+    expect(res.status).toBe('pending');
+  });
+
+  it('should reject with COMPLETE_FAILED then set reason http_400 on a non-retryable 4xx', async () => {
+    const http = makeHttp([{ status: 400, data: { error: { code: 'BAD_SIGNATURE' } } }]);
+    await expect(
+      createClient(http).complete('k', undefined, handle, () => 0)
+    ).rejects.toMatchObject({ code: MAGIC_ERROR_CODES.COMPLETE_FAILED, reason: 'http_400' });
+  });
+
+  it('should use the variant route then post to checkouts shopify complete', async () => {
+    const http = makeHttp([{ status: 200, data: {} }]);
+    await createClient(http).complete(
+      'k',
+      { shopify_pre_payment_guardrail: 'variant_on' },
+      handle,
+      () => 0
+    );
+    expect(http.calls[0].url).toContain('/checkouts/shopify/complete');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npm test -- src/magic/core/__tests__/client.test.js
+```
+Expected: FAIL — cannot find module `../client`.
+
+- [ ] **Step 3: Implement**
+
+Create `src/magic/core/client.js`:
+
+```js
+'use strict';
+
+import {
+  initUrl,
+  completeUrl,
+  POLL_BUDGET_MS,
+  BACKOFF_INITIAL_MS,
+  BACKOFF_CAP_MS,
+} from './endpoints';
+import { MagicCheckoutError, MAGIC_ERROR_CODES } from './errors';
+
+// MCS signals "I have the request, my worker owns placement from here" through
+// these. They are NOT failures: retrying past them buys nothing, and surfacing
+// them as errors would tell a shopper their order failed when it has not.
+const PENDING_CODES = ['DELEGATED_TO_SQS', 'ALREADY_PLACED', 'RETRY_FAILED'];
+
+function errorCodeOf(data) {
+  if (!data) return undefined;
+  if (data.error && typeof data.error.code === 'string') return data.error.code;
+  return typeof data.code === 'string' ? data.code : undefined;
+}
+
+function backoffFor(attempt) {
+  return Math.min(BACKOFF_INITIAL_MS * Math.pow(2, attempt), BACKOFF_CAP_MS);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function createClient(http) {
+  async function init(key, body) {
+    let res;
+    try {
+      res = await http.post(initUrl(key), body);
+    } catch (e) {
+      throw new MagicCheckoutError(MAGIC_ERROR_CODES.ORDER_CREATE_FAILED, 'network', {
+        message: e && e.message,
+      });
+    }
+    if (res.status !== 200) {
+      throw new MagicCheckoutError(
+        MAGIC_ERROR_CODES.ORDER_CREATE_FAILED,
+        `http_${res.status}`,
+        { status: res.status }
+      );
+    }
+    const data = res.data || {};
+    if (!data.order_id) {
+      throw new MagicCheckoutError(
+        MAGIC_ERROR_CODES.ORDER_CREATE_FAILED,
+        'missing_order_id',
+        {}
+      );
+    }
+    return { order_id: data.order_id, experiments: data.experiments };
+  }
+
+  // Confirms MCS RECEIVED the request; it does not wait for the Shopify order.
+  // Once MCS has it, the mutex, the 24h placed-marker and the SQS worker own
+  // the outcome, so the client waiting longer changes nothing a shopper sees.
+  async function complete(key, experiments, handle, now) {
+    const url = completeUrl(key, experiments);
+    const started = now();
+    let attempt = 0;
+
+    for (;;) {
+      let res;
+      let transportError = null;
+      try {
+        res = await http.post(url, handle);
+      } catch (e) {
+        transportError = e;
+      }
+
+      if (!transportError) {
+        if (res.status === 200) {
+          return { status: 'placed', data: res.data || {} };
+        }
+        if (PENDING_CODES.indexOf(errorCodeOf(res.data)) !== -1) {
+          return { status: 'pending', data: res.data || {} };
+        }
+        if (res.status < 500) {
+          throw new MagicCheckoutError(
+            MAGIC_ERROR_CODES.COMPLETE_FAILED,
+            `http_${res.status}`,
+            { status: res.status, handle }
+          );
+        }
+      }
+
+      // 5xx or transport failure: retry is safe because MCS is idempotent
+      // (mutex + 24h marker + Shopify search fallback).
+      if (now() - started >= POLL_BUDGET_MS) {
+        return { status: 'pending', data: {} };
+      }
+      await sleep(backoffFor(attempt));
+      attempt += 1;
+    }
+  }
+
+  return { init, complete };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+npm test -- src/magic/core/__tests__/client.test.js
+```
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/magic/core/client.js src/magic/core/__tests__/client.test.js
+git commit -m "feat(magic): add init and complete HTTP client"
+```
+
+---
+
+## Task 11: Orchestrator
+
+**Files:**
+- Create: `src/magic/core/openMagicCheckout.js`, `src/magic/core/index.js`
+- Test: `src/magic/core/__tests__/openMagicCheckout.test.js`
+
+**Interfaces:**
+- Consumes: `createClient` (Task 10); `MagicCheckoutError`, `MAGIC_ERROR_CODES` (Task 8)
+- Produces: `createMagicCheckout({ host, http, now })` → `{ openMagicCheckout(options) }`
+  - `host.open(options)` → void
+  - `host.subscribe({ onSuccess, onError })` → `unsubscribe()`
+  - `openMagicCheckout({ key, storefront_access_token, cart_id })` → `Promise<{ order_id, order_status_url, payment_id, status }>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/magic/core/__tests__/openMagicCheckout.test.js`:
+
+```js
+const { createMagicCheckout } = require('../index');
+const { MAGIC_ERROR_CODES } = require('../errors');
+
+function makeHost() {
+  const host = {
+    opened: [],
+    handlers: null,
+    unsubscribed: false,
+    open: jest.fn((options) => host.opened.push(options)),
+    subscribe: jest.fn((handlers) => {
+      host.handlers = handlers;
+      return () => { host.unsubscribed = true; };
+    }),
+  };
+  return host;
+}
+
+function makeHttp(responses) {
+  const queue = responses.slice();
+  const calls = [];
+  return {
+    calls,
+    post: jest.fn((url, body) => {
+      calls.push({ url, body });
+      const next = queue.shift();
+      if (next instanceof Error) return Promise.reject(next);
+      return Promise.resolve(next);
+    }),
+  };
+}
+
+const OPTIONS = {
+  key: 'rzp_test_k',
+  storefront_access_token: 'sf-token',
+  cart_id: 'gid://shopify/Cart/c1-abc',
+};
+
+const SUCCESS = {
+  razorpay_payment_id: 'pay_1',
+  razorpay_order_id: 'order_1',
+  razorpay_signature: 'sig_1',
+};
+
+function flush() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('openMagicCheckout', () => {
+  it('should complete every phase then resolve with the shopify order', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1', experiments: {} } },
+      { status: 200, data: { order_id: 'shop_1', order_status_url: 'https://s/o/1' } },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+
+    expect(host.opened[0]).toEqual({
+      key: 'rzp_test_k',
+      order_id: 'order_1',
+      one_click_checkout: true,
+    });
+
+    host.handlers.onSuccess(SUCCESS);
+    await expect(promise).resolves.toMatchObject({
+      order_id: 'shop_1',
+      order_status_url: 'https://s/o/1',
+      payment_id: 'pay_1',
+      status: 'placed',
+    });
+  });
+
+  it('should never send cart data to the modal then pass only key and order id', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1' } },
+      { status: 200, data: {} },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+    await promise;
+
+    expect(Object.keys(host.opened[0]).sort()).toEqual([
+      'key',
+      'one_click_checkout',
+      'order_id',
+    ]);
+  });
+
+  it('should not call complete when the user dismisses then reject as cancelled', async () => {
+    const host = makeHost();
+    const http = makeHttp([{ status: 200, data: { order_id: 'order_1' } }]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onError({ code: 0, description: 'cancelled' });
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.CHECKOUT_CANCELLED,
+    });
+    expect(http.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject as payment failed then pass the native code through', async () => {
+    const host = makeHost();
+    const http = makeHttp([{ status: 200, data: { order_id: 'order_1' } }]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onError({ code: 2, description: 'network' });
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.PAYMENT_FAILED,
+      details: { code: 2, description: 'network' },
+    });
+  });
+
+  it('should reject before opening the modal then never call host open on phase one failure', async () => {
+    const host = makeHost();
+    const http = makeHttp([{ status: 500, data: {} }]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    await expect(sdk.openMagicCheckout(OPTIONS)).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.ORDER_CREATE_FAILED,
+    });
+    expect(host.open).not.toHaveBeenCalled();
+  });
+
+  it('should resolve as pending then report status pending when MCS defers', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1' } },
+      { status: 422, data: { error: { code: 'DELEGATED_TO_SQS' } } },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+
+    await expect(promise).resolves.toMatchObject({ status: 'pending', payment_id: 'pay_1' });
+  });
+
+  it('should attach the handle then include it on every phase three rejection', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1' } },
+      { status: 400, data: { error: { code: 'BAD_SIGNATURE' } } },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.COMPLETE_FAILED,
+      details: {
+        handle: {
+          razorpay_order_id: 'order_1',
+          razorpay_payment_id: 'pay_1',
+          razorpay_signature: 'sig_1',
+          key: 'rzp_test_k',
+        },
+      },
+    });
+  });
+
+  it('should unsubscribe then release the listener on every terminal path', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1' } },
+      { status: 200, data: {} },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+    await promise;
+
+    expect(host.unsubscribed).toBe(true);
+  });
+
+  const invalid = {
+    'should reject when key is missing then report missing_key': [
+      { storefront_access_token: 't', cart_id: 'c' },
+      'missing_key',
+    ],
+    'should reject when cart_id is missing then report missing_cart_id': [
+      { key: 'k', storefront_access_token: 't' },
+      'missing_cart_id',
+    ],
+    'should reject when the storefront token is missing then report missing_storefront_access_token': [
+      { key: 'k', cart_id: 'c' },
+      'missing_storefront_access_token',
+    ],
+    'should reject a cart object then report cart_not_allowed': [
+      { key: 'k', cart_id: 'c', storefront_access_token: 't', shopify_cart: { items: [] } },
+      'cart_not_allowed',
+    ],
+  };
+
+  Object.entries(invalid).forEach(([name, [options, reason]]) => {
+    it(name, async () => {
+      const host = makeHost();
+      const http = makeHttp([]);
+      const sdk = createMagicCheckout({ host, http, now: () => 0 });
+      await expect(sdk.openMagicCheckout(options)).rejects.toMatchObject({
+        code: MAGIC_ERROR_CODES.INVALID_OPTIONS,
+        reason,
+      });
+      expect(http.post).not.toHaveBeenCalled();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npm test -- src/magic/core/__tests__/openMagicCheckout.test.js
+```
+Expected: FAIL — cannot find module `../index`.
+
+- [ ] **Step 3: Implement the orchestrator**
+
+Create `src/magic/core/openMagicCheckout.js`:
+
+```js
+'use strict';
+
+import { MagicCheckoutError, MAGIC_ERROR_CODES } from './errors';
+
+const NATIVE_PAYMENT_CANCELED = 0;
+
+// A cart object must never reach us. Prices and line items belong server-side,
+// and accepting one here would put them in a publicly-readable package and on
+// the wire from a device we do not control.
+function validate(options) {
+  const o = options || {};
+  if (!o.key) return 'missing_key';
+  if (!o.cart_id) return 'missing_cart_id';
+  if (!o.storefront_access_token) return 'missing_storefront_access_token';
+  if (o.shopify_cart || o.cart || o.line_items) return 'cart_not_allowed';
+  return null;
+}
+
+export function makeOpenMagicCheckout({ host, client }) {
+  return function openMagicCheckout(options) {
+    const invalidReason = validate(options);
+    if (invalidReason) {
+      return Promise.reject(
+        new MagicCheckoutError(MAGIC_ERROR_CODES.INVALID_OPTIONS, invalidReason, {})
+      );
+    }
+
+    const { key, cart_id, storefront_access_token } = options;
+
+    return client
+      .init(key, { cart_id, storefront_access_token })
+      .then(({ order_id, experiments }) => {
+        return new Promise((resolve, reject) => {
+          let unsubscribe = null;
+          const release = () => {
+            if (unsubscribe) unsubscribe();
+            unsubscribe = null;
+          };
+
+          unsubscribe = host.subscribe({
+            onSuccess: (data) => {
+              // The handle is assembled BEFORE phase 3 so it can be attached to
+              // any failure. Without it a caller cannot retry a completion, and
+              // a captured payment has no route to an order.
+              const handle = {
+                razorpay_order_id: data.razorpay_order_id || order_id,
+                razorpay_payment_id: data.razorpay_payment_id,
+                razorpay_signature: data.razorpay_signature,
+                key,
+              };
+              client
+                .complete(key, experiments, handle)
+                .then((result) => {
+                  release();
+                  resolve({
+                    order_id: result.data.order_id,
+                    order_status_url: result.data.order_status_url,
+                    total_amount: result.data.total_amount,
+                    payment_id: handle.razorpay_payment_id,
+                    status: result.status,
+                  });
+                })
+                .catch((err) => {
+                  release();
+                  err.details = Object.assign({}, err.details, { handle });
+                  reject(err);
+                });
+            },
+            onError: (data) => {
+              release();
+              const cancelled = data && data.code === NATIVE_PAYMENT_CANCELED;
+              reject(
+                new MagicCheckoutError(
+                  cancelled
+                    ? MAGIC_ERROR_CODES.CHECKOUT_CANCELLED
+                    : MAGIC_ERROR_CODES.PAYMENT_FAILED,
+                  cancelled ? 'user_cancelled' : 'gateway_error',
+                  data
+                )
+              );
+            },
+          });
+
+          // Exactly the option set a standard integration passes today.
+          // isMagic() activates from the order's line_items_total plus the
+          // merchant's server-side 1CC feature, so no cart option is needed.
+          host.open({ key, order_id, one_click_checkout: true });
+        });
+      });
+  };
+}
+```
+
+- [ ] **Step 4: Implement the factory**
+
+Create `src/magic/core/index.js`:
+
+```js
+'use strict';
+
+import { createClient } from './client';
+import { makeOpenMagicCheckout } from './openMagicCheckout';
+
+// `now` is injected so the phase-3 budget is testable with a fake clock rather
+// than by sleeping in tests.
+export function createMagicCheckout({ host, http, now }) {
+  const clock = now || (() => Date.now());
+  const rawClient = createClient(http);
+  const client = {
+    init: rawClient.init,
+    complete: (key, experiments, handle) =>
+      rawClient.complete(key, experiments, handle, clock),
+  };
+  return { openMagicCheckout: makeOpenMagicCheckout({ host, client }) };
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+npm test -- src/magic/core/__tests__/
+```
+Expected: PASS — all core suites including the purity guard.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/magic/core/openMagicCheckout.js src/magic/core/index.js src/magic/core/__tests__/openMagicCheckout.test.js
+git commit -m "feat(magic): add three-phase orchestrator"
+```
+
+---
+
+## Task 12: React Native adapter and public API
+
+**Files:**
+- Create: `src/magic/adapters/reactNative.js`
+- Modify: `RazorpayCheckout.js`, `src/types.ts`
+- Test: `__tests__/magic.integration.test.js`
+
+**Interfaces:**
+- Consumes: `createMagicCheckout` (Task 11); `EVENT_NAMES`, `getEmitter`, `getNativeModule`, `removeSubscriptions` (Task 7)
+- Produces: `RazorpayCheckout.openMagicCheckout(options)` → `Promise<MagicCheckoutResult>`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `__tests__/magic.integration.test.js`:
+
+```js
+const { makeSuite, EVENTS } = require('./helpers/suite');
+
+describe('openMagicCheckout through the RN adapter', () => {
+  const OPTIONS = {
+    key: 'rzp_test_k',
+    storefront_access_token: 'sf-token',
+    cart_id: 'gid://shopify/Cart/c1-abc',
+  };
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  function respond(bodies) {
+    const queue = bodies.slice();
+    global.fetch.mockImplementation(() => {
+      const next = queue.shift();
+      return Promise.resolve({
+        status: next.status,
+        json: () => Promise.resolve(next.body),
+      });
+    });
+  }
+
+  it('should open the native modal then resolve after completion', async () => {
+    respond([
+      { status: 200, body: { order_id: 'order_1', experiments: {} } },
+      { status: 200, body: { order_id: 'shop_1', order_status_url: 'https://s/o/1' } },
+    ]);
+    const ts = makeSuite();
+
+    const promise = ts.RazorpayCheckout.openMagicCheckout(OPTIONS);
+    await new Promise((r) => setImmediate(r));
+
+    expect(ts.native.open).toHaveBeenCalledWith({
+      key: 'rzp_test_k',
+      order_id: 'order_1',
+      one_click_checkout: true,
+    });
+
+    ts.emitter.emit(EVENTS.success, {
+      razorpay_payment_id: 'pay_1',
+      razorpay_order_id: 'order_1',
+      razorpay_signature: 'sig_1',
+    });
+
+    await expect(promise).resolves.toMatchObject({ order_id: 'shop_1', status: 'placed' });
+  });
+
+  it('should leave open() untouched then keep its listeners working', async () => {
+    const ts = makeSuite();
+    const promise = ts.RazorpayCheckout.open({ key: 'k' });
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_2' });
+    await expect(promise).resolves.toEqual({ razorpay_payment_id: 'pay_2' });
+  });
+
+  it('should release its listener then leave none registered after Magic resolves', async () => {
+    respond([
+      { status: 200, body: { order_id: 'order_1' } },
+      { status: 200, body: {} },
+    ]);
+    const ts = makeSuite();
+    const promise = ts.RazorpayCheckout.openMagicCheckout(OPTIONS);
+    await new Promise((r) => setImmediate(r));
+    ts.emitter.emit(EVENTS.success, { razorpay_payment_id: 'pay_1' });
+    await promise;
+    expect(ts.emitter.listenerCount(EVENTS.success)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npm test -- __tests__/magic.integration.test.js
+```
+Expected: FAIL — `ts.RazorpayCheckout.openMagicCheckout is not a function`.
+
+- [ ] **Step 3: Implement the adapter**
+
+Create `src/magic/adapters/reactNative.js`. This is the only file in the Magic feature that knows a native bridge exists.
+
+```js
+'use strict';
+
+import {
+  EVENT_NAMES,
+  getEmitter,
+  getNativeModule,
+} from '../../internal/checkoutSession';
+
+// Magic subscribes with per-call handles rather than reusing
+// removeSubscriptions(), because that helper clears listeners globally and
+// would tear down a concurrent open() as a side effect.
+export function createReactNativeHost() {
+  return {
+    open(options) {
+      getNativeModule().open(options);
+    },
+    subscribe({ onSuccess, onError }) {
+      const emitter = getEmitter();
+      const successSub = emitter.addListener(EVENT_NAMES.SUCCESS, onSuccess);
+      const errorSub = emitter.addListener(EVENT_NAMES.ERROR, onError);
+      return () => {
+        successSub.remove();
+        errorSub.remove();
+      };
+    },
+  };
+}
+
+// React Native ships fetch, so this adds no dependency. It exists as a port so
+// the core can be tested without a network and reused by a non-RN wrapper.
+export function createFetchHttp() {
+  return {
+    post(url, body) {
+      return fetch(url, {
+        method: 'POST',
+        headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }).then((res) =>
+        res
+          .json()
+          .catch(() => ({}))
+          .then((data) => ({ status: res.status, data }))
+      );
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Wire the public API**
+
+Modify `RazorpayCheckout.js` — add the imports and the static method, leaving `open` and `onExternalWalletSelection` exactly as Task 7 left them:
+
+```js
+import { createMagicCheckout } from './src/magic/core';
+import {
+  createReactNativeHost,
+  createFetchHttp,
+} from './src/magic/adapters/reactNative';
+
+let magic;
+function getMagic() {
+  if (!magic) {
+    magic = createMagicCheckout({
+      host: createReactNativeHost(),
+      http: createFetchHttp(),
+    });
+  }
+  return magic;
+}
+```
+
+and inside the class, after `open`:
+
+```js
+  static openMagicCheckout(options) {
+    return getMagic().openMagicCheckout(options);
+  }
+```
+
+- [ ] **Step 5: Add the types**
+
+Append to `src/types.ts`. Do not narrow the existing `[key: string]: any` on `RazorpayOptions`.
+
+```ts
+export type MagicCheckoutOptions = {
+  /** Razorpay public key_id. Authenticates the init call and identifies the merchant. */
+  key: string;
+  /** The app's Shopify Storefront access token. Only the app that created a cart can read it. */
+  storefront_access_token: string;
+  /** Storefront cart id, e.g. "gid://shopify/Cart/c1-abc". An identifier — never a cart object. */
+  cart_id: string;
+};
+
+export type MagicCheckoutResult = {
+  /** Shopify order id. Undefined while status is 'pending'. */
+  order_id?: string;
+  order_status_url?: string;
+  total_amount?: number;
+  payment_id: string;
+  /** 'placed' — Shopify order exists. 'pending' — accepted, being placed asynchronously. */
+  status: 'placed' | 'pending';
+};
+
+export type MagicHandle = {
+  razorpay_order_id: string;
+  razorpay_payment_id: string;
+  razorpay_signature: string;
+  key: string;
+};
+```
+
+- [ ] **Step 6: Run the whole suite**
+
+```bash
+npm test
+```
+Expected: PASS — every suite, including the Task 6 characterisation tests unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add RazorpayCheckout.js src/magic/adapters src/types.ts __tests__/magic.integration.test.js
+git commit -m "feat(magic): expose openMagicCheckout via the React Native adapter"
+```
+
+---
+
+## Task 13: Documentation
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add the Magic Checkout section**
+
+Append to `README.md`:
+
+````markdown
+## Magic Checkout (Shopify)
+
+Magic Checkout (1CC) for Shopify merchants shipping a React Native app. Requires the
+merchant to be 1CC-enabled server-side; no SDK flag turns it on.
+
+```js
+import RazorpayCheckout from 'react-native-razorpay';
+
+try {
+  const result = await RazorpayCheckout.openMagicCheckout({
+    key: 'rzp_live_xxxxxxxx',
+    storefront_access_token: '<your Shopify Storefront access token>',
+    cart_id: 'gid://shopify/Cart/c1-abcdef',
+  });
+
+  if (result.status === 'placed') {
+    // Shopify order exists. result.order_status_url is safe to show.
+  } else {
+    // 'pending' — payment captured and accepted; Razorpay is placing the order.
+    // Show "we're confirming your order", never "failed".
+  }
+} catch (error) {
+  // error.code is one of MAGIC_ORDER_CREATE_FAILED, MAGIC_CHECKOUT_CANCELLED,
+  // MAGIC_PAYMENT_FAILED, MAGIC_COMPLETE_FAILED, MAGIC_INVALID_OPTIONS.
+  // error.reason carries the specific cause.
+}
+```
+
+### Parameters
+
+| Parameter | Required | Notes |
+|---|---|---|
+| `key` | yes | Razorpay public `key_id`. Already shipped in your app today |
+| `storefront_access_token` | yes | Your Shopify Storefront access token. A cart is only readable by the Storefront app that created it, which is why this is yours and not Razorpay's |
+| `cart_id` | yes | Storefront cart **id**, not a cart object. Passing a cart is rejected — prices stay server-side |
+
+### Recovering a payment whose order did not confirm
+
+If the app is killed between payment and confirmation, `complete` may never reach
+Razorpay. Everything needed to retry is already in the payment payload, so no extra
+SDK call is required — persist it when the payment succeeds and POST it later:
+
+```js
+POST https://api.razorpay.com/v1/1cc/shopify/complete?key_id=<key>
+{
+  "razorpay_order_id":   "...",
+  "razorpay_payment_id": "...",
+  "razorpay_signature":  "...",
+  "key":                 "..."
+}
+```
+
+Retrying is safe — Razorpay guarantees at most one Shopify order per Razorpay order for
+24 hours.
+
+### Not supported in this release
+
+Analytics fan-out (GA4, FB Pixel, MoEngage, Clevertap), coupon prefill UI,
+abandoned-cart recovery, loyalty coins, gift cards, and WooCommerce or Magento.
+````
+
+- [ ] **Step 2: Verify the sample compiles conceptually**
+
+```bash
+npm test
+```
+Expected: PASS. Then re-read the README snippet against `src/types.ts` and confirm every field name matches exactly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document openMagicCheckout"
+```
+
+---
+
+## Pre-Ramp Gate — human and cross-team, not agent-executable
+
+Do not publish or ramp until every row is resolved.
+
+| # | Item | Owner |
+|---|---|---|
+| 1 | Task 0 passed on **both** platforms | Implementer |
+| 2 | AppBrew's Storefront token carries `unauthenticated_read_product_*` for `image`, `productType`, `taxable`, `description` (assumption A4) | AppBrew |
+| 3 | Confirm `MobileInit`'s passthrough carries both `order_id` and `experiments` against a real merchant. Web reads both from this response (`shopify/order.ts:54`, `handlers.ts:86`), but verify rather than infer | Magic Checkout team |
+| 4 | Latency budget for `/v1/magic/shopify/init` — it sits directly in the tap-to-modal path | Magic Checkout team |
+| 5 | `GET /v1/magic/shopify/order/status` load sanity-check if the pending path is later given a poll | Magic Checkout team |
+| 6 | File the reconciliation-sweep ask: 1CC orders with a captured payment and no Shopify order. Closes the app-killed window, and benefits web equally | Magic Checkout team |
+| 7 | End-to-end on device: cart → init → payment → Shopify order visible in Shopify admin | Implementer |
+| 8 | Force a slow/failing `complete` and confirm the pending path resolves rather than erroring | Implementer |
+
+## Monitoring after ramp
+
+| Metric | Why |
+|---|---|
+| `MAGIC_COMPLETE_FAILED` by `reason` | Primary correctness alarm — each is a possible lost order |
+| `MAGIC_PAYMENT_SUCCESS` minus `MAGIC_COMPLETE_SUCCESS` | The payment-without-order gauge; should trend to zero |
+| `MOBILE_INIT_FAILED` by `reason` | Phase-1 endpoint health |
+| `MOBILE_INIT_SUCCESS` p95 latency | Tap-to-modal stall |
+| `MOBILE_CART_FETCH_FAILED` by `reason` | Distinguishes bad tokens from Shopify outages |
+
+## Spec Coverage
+
+| Spec section | Task |
+|---|---|
+| §4 three-phase flow | 10, 11 |
+| §5.1 `/v1/magic/shopify/init` | 1, 2, 3, 4 |
+| §5.1 security boundary (`ShopName` pinned) | 3 |
+| §5.1 mapper rules (`gid`→`int64`, bare `c1-`) | 2 |
+| §5.1 new mobile-only query | 1 |
+| §5.2 `order_id`-only modal options | 11 |
+| §5.2 listener extraction | 7 |
+| §5.3 no `checkout` FE changes | 0 (verification) |
+| §5.4 bounded receipt-confirmation | 10 |
+| §5.4 handle documented, not built | 13 |
+| §6 cross-platform seam | 9 (purity guard), 11, 12 |
+| §7 error handling table | 8, 10, 11 |
+| §8 testing strategy | 5, 6, and each task's tests |
+| §9 A1 | 0 |
+| §9 A4 | Pre-Ramp Gate #2 |
+| §9 A5 | Pre-Ramp Gate #3 |
+| §10 reconciliation follow-up | Pre-Ramp Gate #6 |
+
+## Not covered here
+
+- `checkout` (FE) changes — none required. If Task 0 fails, that changes and this plan needs revision.
+- Native Android/iOS changes — none required.
+- Analytics fan-out, coupon prefill, abandoned cart, Splitz sync, loyalty, gift cards, WooCommerce, Magento — out of scope per spec v6 §3.
+- The `merchantevent` bridge channel — v2, and the gate on the whole event-driven feature class.

--- a/docs/superpowers/specs/2026-08-28-rn-magic-shopify-design.md
+++ b/docs/superpowers/specs/2026-08-28-rn-magic-shopify-design.md
@@ -1,0 +1,307 @@
+Design Record · v7
+
+# Magic Checkout (Shopify) in react-native-razorpay — revised architecture
+
+**Author:** n.maneeshgupta · **Pod:** Magic Checkout · **BU:** Platforms · **Date:** Aug 28, 2026
+**Status:** Approved in brainstorm — pending written review
+
+**Supersedes** the architecture sections of `2026-08-25-rn-magic-shopify-design.md`
+(aidocs `doc_nlfwhc7wob4hgy7i`, v6). The problem statement (§1), scope (§2), out-of-scope
+(§3) and NFRs (§9) of v6 still stand. §7.5–§8 and §11 of v6 are replaced by this document.
+v6 is not edited in place because it is published in aidocs; this is the honest delta.
+
+---
+
+## 1. Why v6 was wrong
+
+v6 proposed `openMagicCheckout()` inside `react-native-razorpay` making three `fetch`
+calls to MCS, with a client-side handle, bounded poll and `resumeMagicCheckout`. Reading
+the five repos invalidated four of its load-bearing claims.
+
+| # | v6 claim | What the code says |
+|---|---|---|
+| D1 | Phase 1 needs a new MCS endpoint | `checkout.js` already calls `magic/checkout/shopify` and `magic/order/shopify` (`initialize-shopify.ts:169`, `shopify/order.ts:46`), which are `1cc-consumer-app`'s existing `CreateCheckout` / `CreateOrderAndGetPreferences` routes |
+| D2 | `_.integration_type: 'shopify_checkout'` activates Magic | No such value is read anywhere. Nothing would activate |
+| D3 | The SDK must pass `shopify_cart` | The Magic UI renders from `prefsOrder.line_items` / `line_items_total` when not in lite flow (`main-modal/helpers/magic.ts:176-180`). `isMagic()` is satisfied by `hasLineItemsTotal` alone (`isMagic.ts:20,26`) |
+| D4 | The SDK cannot read Splitz, so the complete route must be hardcoded | `magic-plugins` doesn't read Splitz from a client SDK either — experiments arrive in the create-order **server response** (`setMagicExperiments(data.experiments)`, `handlers.ts:86`) |
+
+D3 and D4 are the consequential ones. D3 removes all cart data from the device; D4 removes
+the only permanent risk of putting orchestration in a pinned npm package.
+
+## 2. The organising principle
+
+On web, `magic-plugins` — the **merchant-side host integration layer** — orchestrates.
+`checkout.js` renders the Magic UI and takes the payment; it never brackets the modal.
+
+> `magic-plugins` : Shopify storefront page :: `react-native-razorpay` : merchant RN app
+
+`react-native-razorpay` occupies the same architectural position, so it takes the same
+role. This is the pattern, stated plainly, and every decision below follows from it.
+
+**Where the analogy breaks, and how we pay for it.** `magic-plugins` is a Razorpay-deployed
+CDN script — a fix reaches every storefront on next page load. An npm package is pinned by
+the merchant and gated behind app-store review, so a fix can take months. We do not get both
+properties on mobile. We keep the architectural position and neutralise the deployment cost
+by making the SDK **thin and server-tunable**: every mutable decision (endpoint choice,
+experiment values, thresholds) arrives in the phase-1 response rather than living in a
+constant. Static code in a pinned binary is only dangerous if it encodes a decision that
+might change.
+
+## 3. Goals and non-goals
+
+**Goals**
+
+- A React Native app completes a Shopify Magic Checkout end-to-end in one SDK call.
+- `open()`'s public behaviour is unchanged, enforced by characterisation tests.
+- No Shopify cart data, line items or monetary amounts ever reach the device.
+- No native code changes. No `checkout.js` changes.
+- Full happy path testable in CI — no device, no Shopify store, no merchant key.
+
+**Non-goals**
+
+- Feature parity with `magic-plugins` (analytics fan-out, abandoned cart, coupon prefill,
+  experiments sync, loyalty, gift cards) — v6 §3 stands unchanged.
+- Cross-framework reuse in v1. The core is written to allow a Flutter/Capacitor adapter
+  later (§6), but no second wrapper ships now.
+- A storage dependency. The SDK persists nothing.
+
+## 4. Chosen approach
+
+Three phases, orchestrated in the SDK's JS layer, exactly as `magic-plugins` does on web.
+
+```
+RN app   openMagicCheckout({ key, storefront_access_token, cart_id })
+  │
+  ├─1─►  POST /v1/magic/shopify/init?key_id=…        1cc-consumer-app  ← NEW
+  │      { storefront_access_token, cart_id }
+  │      ← { order_id, experiments }
+  │
+  ├─2─►  open({ key, order_id })                     existing native path, UNCHANGED
+  │      native SDK WebView → checkout.js → isMagic() → Magic UI → payment
+  │      ← Razorpay::PAYMENT_SUCCESS { payment_id, order_id, signature }
+  │
+  └─3─►  POST 1cc/shopify/complete  |  checkouts/shopify/complete
+         branch on experiments['shopify_pre_payment_guardrail'] === 'variant_on'
+         ← resolve
+```
+
+### 4.1 What was chosen over what
+
+| Decision | Chosen | Over | Why |
+|---|---|---|---|
+| Orchestrator | SDK JS layer | `checkout.js` | Matches `magic-plugins`' position; release independence; CI-testable without a device; zero blast radius on a bundle serving 100% of checkout traffic |
+| Phase-1 backend | New `/v1/magic/shopify/init` in consumer-app | Two existing calls | One round trip on mobile networks; cart and order cannot drift |
+| Modal input | `order_id` only | `order_id` + `shopify_cart` | Nothing cart-shaped crosses the bridge — see §5.2 |
+| Cart source | Server reads it via the app's Storefront token | App maps and sends a `/cart.js` cart | Keeps every price server-side |
+| Complete route | Direct call, branched on server-supplied experiments | A consumer-app proxy | Byte-for-byte the `magic-plugins` pattern; no second endpoint |
+| Phase-3 semantics | Bounded receipt-confirmation | Await placement | See §5.4 |
+
+### 4.2 Rejected
+
+- **`checkout.js` orchestrates.** Would need three FE changes and gives no npm release
+  path. Its one real advantage — instant fixes for every platform at once — is bought at
+  the cost of blast radius on the highest-traffic bundle Razorpay ships.
+- **`_.integration_type: 'x'` to activate lite mode.** `isMagicXFlow()` is a suppression
+  flag in ~14 places (`prefill-coupon.ts:52`, `auto-coupon.ts:39`,
+  `automatic-discount-sync-with-contact-details.ts:43,120`, `eligibility.ts:65,189`,
+  `coupon-utils.ts:97`) and would silently disable coupons.
+- **A portable core as a separate npm package.** A second release train for one consumer.
+  The seam (§6) gets the benefit without the package.
+
+## 5. Components and boundaries
+
+### 5.1 `1cc-consumer-app` — `POST /v1/magic/shopify/init`
+
+The only new endpoint. `checkout.js` already calls this exact path
+(`initialize-shopify.ts:226`, behind `isMagicShopifyLoadtimeV2Enabled()`), but **no backend
+implements it** in `1cc-consumer-app`, `magic-checkout-service` or the API monolith —
+confirmed. So the contract is ours to define.
+
+```
+req  { storefront_access_token, cart_id }                        + ?key_id=
+  1. merchantConfig.GetFromCache(key_id)                          existing
+  2. credentials{ ShopName: *merchantConfig.ShopId,               ← pinned server-side
+                  StorefrontAccessToken: req.storefront_access_token }
+  3. GetMobileCartDetails(creds, cart_id)                         NEW query + gw method
+  4. toCartDTO(sfCart)                                            NEW mapper
+  5. CreateCheckout(...)               → shopify_checkout_id      existing, unchanged
+  6. CreateOrderAndGetPreferences(...) → order_id + preferences   existing, unchanged
+resp { order_id, experiments, ... }
+```
+
+Steps 5 and 6 compose because `CreateOrderAndGetPreferences` needs only
+`shopify_checkout_id` + `key_id` and re-reads cart and checkout from the cache step 5 wrote
+(`checkout.go:555`).
+
+**Why the app's Storefront token and not the merchant's.** The cart is created by AppBrew's
+Storefront app, so it is readable only with AppBrew's token. `merchantConfig` does carry a
+`StorefrontAccessToken` (`checkout.go:372`), but it belongs to Razorpay's Shopify app and
+is used for step 5's re-creation, not step 3's read.
+
+**Security boundary.** `ShopName` always comes from `merchantConfig.ShopId`, never from the
+request. A supplied token therefore cannot redirect the outbound call at another shop; the
+worst a bad token achieves is a 401 from the merchant's own domain.
+
+**Mapper rules.** `gid://shopify/ProductVariant/123` → `int64` 123.
+`gid://shopify/Cart/c1-abc` → `Cart.Token = "c1-abc"`, so the cart-token→unique-ID
+mapping (`storeCartTokenToUniqueIDMapping`, `checkout.go:164`) keeps working. That
+function is service-level, so the mobile path reaches it.
+
+> **Correction, verified during execution.** This section previously also cited
+> `observeCartProperties`' `c1-` prefix check. That function is controller-only
+> (`controllers/checkout/checkout.go:89`); `MobileInit` calls the service directly and
+> bypasses it, so cart-property metrics do not fire for mobile carts. Harmless — the
+> metric detects `/cart.js` schema drift from the web plugin, impossible for a
+> server-built cart — but it is not why the token is stripped.
+
+**New query, not an extended one.** `GetShopifyCartDetailsMutation()`
+(`pkg/shopify/client/graphql/queries.go:268`) omits `image`, `productType`, `taxable` and
+`description`, which `dtos.Item` carries. A separate mobile query avoids widening the
+Storefront response for the coupons path, which shares the existing one.
+
+### 5.2 `react-native-razorpay` — the orchestrator
+
+Phase 2 is the existing path with the existing option set:
+
+```js
+RazorpayCheckout.open({ key, order_id })
+```
+
+Nothing else is required. Verified against `checkout.js`:
+
+- `isMagic()` → true via `hasLineItemsTotal` from the order plus the server-side
+  `hasFeature('one_click_checkout')` (`isMagic.ts:20,22,26`). No cart option needed.
+- `shouldCreateShopifyCheckout()` / `shouldCreateShopifyOrder()` → both false, because both
+  return `isMagicShopifyCheckoutFlow()` which needs lite mode, which needs `merchant_key` in
+  the URL or `isMagicXFlow()` — neither true in a native WebView. **`checkout.js` will not
+  re-create the order.**
+- `getShippingMethodBasedOnExp()` → `'orderId'`, so serviceability uses
+  `getServiceabilityBasedOnOrderId` and never touches `shopify_cart`
+  (`compute-shipping-method.ts:10-28`).
+- `syncShopifyOrderId()` resolves, because `orderIdPromise` is resolved by `setOptions`
+  when `order_id` is present (`options.ts:24`).
+
+`one_click_checkout: true` is passed to mirror web but is not load-bearing — `isMagic()`
+reads the server-side feature, not the option. Confirm on device before removing.
+
+**The one change to existing code.** `open()` calls `removeSubscriptions()` on first
+success (`RazorpayCheckout.js:45`), and it uses `removeAllListeners`, so phase 3 cannot run
+after it. Listener wiring is extracted into an internal helper shared by both entry points,
+preserving `open()`'s public behaviour byte-for-byte — including that listeners are removed
+on first success and that `successCallback`/`errorCallback` take precedence over the
+promise. Characterisation tests land before the extraction.
+
+### 5.3 `checkout` (FE) — no changes
+
+Stated explicitly because v6 assumed otherwise, and because §5.2's four bullets are the
+evidence. If any of them turns out false on device, that is a design-invalidating finding,
+not a bug — escalate rather than patch.
+
+### 5.4 Phase 3 — bounded receipt-confirmation
+
+`PublishCompleteCheckoutMessage` lives inside `complete_checkout.go:1372`, so MCS's SQS
+worker is enqueued **by** the CompleteCheckout flow. There is no payment-webhook-driven
+placement: if the client's `complete` never lands, no order is placed and the retry/refund
+machinery never starts. The call is therefore load-bearing for correctness.
+
+But the client only needs the request to **arrive**. Once MCS has it, placement is owned
+server-side by the mutex, the 24h placed-marker, the Shopify search fallback and the worker
+(3 attempts at ~5/10/15 min, refund on exhaustion). Waiting for the order buys nothing.
+
+| Outcome | Action |
+|---|---|
+| `200` — placed | resolve with `order_status_url`, total |
+| Accepted-pending (`DELEGATED_TO_SQS`, `422` already-placed) | resolve — MCS owns it. **A success path, not an error** |
+| `5xx` / network error | retry within the budget — safe, MCS is idempotent |
+| Budget exhausted, still unknown | resolve, flagged so the app can show "confirming your order" |
+
+One hard client budget, **~8s**, tunable from the phase-1 response. Deliberately not v6's
+30s: bounded to a few seconds, any native SDK tolerates the delay before `oncomplete`, so
+the SDK-timeout question stops being a design risk.
+
+**Residual risk, stated not hidden.** If the app dies inside that window, `complete` never
+lands and nothing recovers it. Two responses, both taken: `PAYMENT_SUCCESS` already carries
+`razorpay_payment_id`, `razorpay_order_id` and `razorpay_signature`, and the app supplied
+`key` — that *is* the recovery handle, so a merchant app can retry `complete` itself with no
+SDK change, documented in the README rather than built. And a server-side reconciliation
+sweep over 1CC orders with a captured payment and no Shopify order is filed as a follow-up
+ask to the MCS team; it is the only thing that closes the window properly, and it benefits
+web equally.
+
+## 6. Cross-platform seam
+
+The core (`src/magic/core/`) imports nothing from `react-native`. It takes two ports:
+
+```
+createMagicCheckout({ host, http })
+  host: { open(options): void, subscribe({onSuccess, onError}): Unsubscribe }
+  http: { post(url, body, {timeout}) }        // default: global fetch
+→ { openMagicCheckout, onMagicEvent }
+```
+
+`src/magic/adapters/reactNative.js` is the only file that knows a bridge exists. A Flutter,
+Capacitor or web wrapper writes its own adapter against the same two methods. This costs
+one indirection now and is the difference between an adapter and a rewrite later. It also
+makes the core testable with zero React Native mocking, which is what delivers the
+"CI, no device" goal.
+
+## 7. Data flow and error handling
+
+| Phase | Failure | Payment at risk | Behaviour |
+|---|---|---|---|
+| 1 | network / 4xx / merchant not 1CC-enabled | No | reject `MAGIC_ORDER_CREATE_FAILED`, `reason` set |
+| 2 | user dismissed | No | reject `MAGIC_CHECKOUT_CANCELLED`, **phase 3 not entered** |
+| 2 | payment error | No | reject `MAGIC_PAYMENT_FAILED`, native code passed through |
+| 3 | pending / already-placed | Yes | resolve — MCS owns placement |
+| 3 | 5xx / network | Yes | retry within budget, then resolve flagged |
+
+Native error codes, verified against `com.razorpay:standard-core` 1.7.18:
+`PAYMENT_CANCELED = 0`, `NETWORK_ERROR = 2`, `INVALID_OPTIONS = 3`, `TLS_ERROR = 6`,
+`INCOMPATIBLE_PLUGIN = 7`.
+
+Log and event names are `UPPER_SNAKE_CASE` in `ACTION_STATUS` form with the cause in a
+queryable `reason` field, never baked into the name:
+`MAGIC_CREATE_ORDER_SUCCESS`/`_FAILED`, `MAGIC_PAYMENT_SUCCESS`/`_FAILED`,
+`MAGIC_COMPLETE_SUCCESS`/`_FAILED`, `MAGIC_COMPLETE_PENDING`.
+
+## 8. Testing strategy
+
+The repo has no test infrastructure today — no jest, no devDependencies, no tests.
+Establishing it is in scope and is task 1.
+
+- **Unit** — cart-input validation, error taxonomy, backoff and budget scheduling with fake
+  timers.
+- **Contract** — request and response shapes against §5.1, mocked `fetch`.
+- **Orchestrator** — every row of the §7 table, plus: complete is never called after
+  dismissal; a `5xx`-then-`200` sequence resolves; budget exhaustion resolves flagged.
+- **Regression** — characterisation tests proving `open()` unchanged, including the
+  `removeAllListeners` quirk and callback precedence.
+- Table-driven, keyed `"should X then Y"`, shared setup behind a suite factory.
+- **Device (UAT)** — the four §5.2 bullets, on both platforms, against a 1CC-enabled test
+  merchant. This is the design-invalidating check and belongs early, not at the end.
+
+## 9. Assumptions
+
+| # | Assumption | Confidence |
+|---|---|---|
+| A1 | Magic renders in the native WebView given `order_id` alone for a 1CC-enabled merchant | High — derived from `isMagic.ts:20,26` and `magic.ts:176-180`; **device-verify first** |
+| A2 | The 1CC order carries `line_items` and `line_items_total` | High — the web native-checkout branch relies on it |
+| A3 | `/v1/magic/shopify/init` has no existing owner | Confirmed by grep across consumer-app, MCS and the API monolith; consumer-app checkout 4 days old |
+| A4 | AppBrew's Storefront token has `unauthenticated_read_product_*` for the new query fields | **Unverified — external confirmation needed** |
+| A5 | `experiments` can be returned from the phase-1 response as web's create response does | Medium — needs MCS/consumer-app agreement |
+
+A5 is load-bearing twice: it supplies the `shopify_pre_payment_guardrail` branch (§4) and
+the phase-3 budget (§5.4). If it cannot be agreed, the fallback is to hardcode
+`1cc/shopify/complete` and an 8s budget — which reinstates v6 §11.1's pre-ramp blocker and
+makes it permanent rather than temporary. That is a materially worse position, so A5 should
+be settled before implementation rather than during it.
+| A6 | Merchant is 1CC-enabled server-side (`features.one_click_checkout`) | Precondition, not ours |
+
+`prefill` is deliberately **omitted** from the phase-1 response. v6 §8.1.3 warned against
+shipping it undefined; the app passes standard checkout `prefill` through options instead.
+
+## 10. Open items
+
+1. A4 — token scopes, with AppBrew.
+2. A5 — `experiments` in the init response, with the Magic Checkout team.
+3. The reconciliation sweep (§5.4) — filed as a follow-up ask, not v1 scope.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'node',
+  moduleFileExtensions: ['js', 'ts', 'json'],
+  testMatch: ['**/__tests__/**/*.test.js'],
+  moduleNameMapper: {
+    '^react-native$': '<rootDir>/__mocks__/react-native.js',
+  },
+  clearMocks: true,
+};

--- a/package.json
+++ b/package.json
@@ -4,11 +4,19 @@
   "description": "React Native wrapper for Razorpay",
   "main": "RazorpayCheckout.js",
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start"
+    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/razorpay/react-native-razorpay.git"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.0",
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-typescript": "^7.24.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
   },
   "codegenConfig": {
     "name": "RNRazorpayCheckoutSpec",

--- a/src/internal/checkoutSession.js
+++ b/src/internal/checkoutSession.js
@@ -1,0 +1,66 @@
+'use strict';
+
+import { NativeModules, NativeEventEmitter } from 'react-native';
+
+// Runtime detection for new architecture.
+// RN <0.74 uses __turboModuleProxy; RN >=0.74 (bridgeless) exposes TurboModuleRegistry and nativeFabricUIManager instead.
+const isTurboModuleEnabled =
+  global.__turboModuleProxy != null ||
+  global.TurboModuleRegistry != null ||
+  global.nativeFabricUIManager != null;
+
+let RazorpayCheckoutModule;
+let RazorpayEventEmitterModule;
+
+if (isTurboModuleEnabled) {
+  try {
+    RazorpayCheckoutModule = require('../NativeRazorpayCheckout').default;
+    RazorpayEventEmitterModule = require('../NativeRazorpayEventEmitter').default;
+  } catch (error) {
+    RazorpayCheckoutModule = NativeModules.RNRazorpayCheckout;
+    RazorpayEventEmitterModule = NativeModules.RazorpayEventEmitter;
+  }
+} else {
+  RazorpayCheckoutModule = NativeModules.RNRazorpayCheckout;
+  RazorpayEventEmitterModule = NativeModules.RazorpayEventEmitter;
+}
+
+const razorpayEvents = new NativeEventEmitter(RazorpayEventEmitterModule);
+
+export const EVENT_NAMES = {
+  SUCCESS: 'Razorpay::PAYMENT_SUCCESS',
+  ERROR: 'Razorpay::PAYMENT_ERROR',
+  EXTERNAL_WALLET: 'Razorpay::EXTERNAL_WALLET_SELECTED',
+};
+
+export function getEmitter() {
+  return razorpayEvents;
+}
+
+export function getNativeModule() {
+  return RazorpayCheckoutModule;
+}
+
+export function removeSubscriptions() {
+  razorpayEvents.removeAllListeners(EVENT_NAMES.SUCCESS);
+  razorpayEvents.removeAllListeners(EVENT_NAMES.ERROR);
+  razorpayEvents.removeAllListeners(EVENT_NAMES.EXTERNAL_WALLET);
+}
+
+// Wires the two payment listeners and launches the native checkout.
+//
+// `teardown` is a parameter rather than a hardcoded removeSubscriptions()
+// because Magic must keep listening past the first success: it still has a
+// Shopify order to place. open() passes the original teardown and so keeps
+// its shipped behaviour exactly.
+export function runCheckout(options, { onSuccess, onError, teardown }) {
+  razorpayEvents.addListener(EVENT_NAMES.SUCCESS, (data) => {
+    onSuccess(data);
+    teardown();
+  });
+  razorpayEvents.addListener(EVENT_NAMES.ERROR, (data) => {
+    onError(data);
+    teardown();
+  });
+  RazorpayCheckoutModule.open(options);
+}

--- a/src/magic/adapters/__tests__/reactNative.test.js
+++ b/src/magic/adapters/__tests__/reactNative.test.js
@@ -1,0 +1,72 @@
+const { createFetchHttp } = require('../reactNative');
+
+// Stands in for a socket that accepts the request and then goes silent — the
+// Android case, where the underlying read has no timeout at all. It only ever
+// settles if the caller aborts it.
+function hangingFetch() {
+  return jest.fn(
+    (url, init) =>
+      new Promise((resolve, reject) => {
+        const signal = init && init.signal;
+        if (signal) signal.addEventListener('abort', () => reject(new Error('Aborted')));
+      })
+  );
+}
+
+describe('createFetchHttp', () => {
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  it('should post json then resolve with the status and the parsed body', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ status: 200, json: () => Promise.resolve({ order_id: 'order_1' }) })
+    );
+
+    const res = await createFetchHttp().post('https://api/x', { cart_id: 'c1' });
+
+    expect(res).toEqual({ status: 200, data: { order_id: 'order_1' } });
+    expect(global.fetch.mock.calls[0][1].body).toBe(JSON.stringify({ cart_id: 'c1' }));
+  });
+
+  // MB1. Without the abort wiring this test does not fail an assertion, it
+  // never returns — which is the production outcome after a payment is taken.
+  it('should abort a hung request then reject once the timeout elapses', async () => {
+    global.fetch = hangingFetch();
+
+    await expect(
+      createFetchHttp().post('https://api/x', {}, { timeout: 20 })
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it('should pass an abort signal then let the transport cancel the request', async () => {
+    global.fetch = hangingFetch();
+
+    createFetchHttp()
+      .post('https://api/x', {}, { timeout: 20 })
+      .catch(() => {});
+
+    expect(global.fetch.mock.calls[0][1].signal).toBeDefined();
+  });
+
+  it('should omit the signal then leave an untimed request unbounded', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ status: 200, json: () => Promise.resolve({}) })
+    );
+
+    await createFetchHttp().post('https://api/x', {});
+
+    expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
+  });
+
+  it('should tolerate a non-json body then resolve with an empty data object', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ status: 502, json: () => Promise.reject(new Error('not json')) })
+    );
+
+    await expect(createFetchHttp().post('https://api/x', {}, { timeout: 500 })).resolves.toEqual({
+      status: 502,
+      data: {},
+    });
+  });
+});

--- a/src/magic/adapters/reactNative.js
+++ b/src/magic/adapters/reactNative.js
@@ -28,19 +28,46 @@ export function createReactNativeHost() {
 
 // React Native ships fetch, so this adds no dependency. It exists as a port so
 // the core can be tested without a network and reused by a non-RN wrapper.
+//
+// RN's fetch never sets a timeout of its own -- on Android the socket read is
+// unbounded -- so the wall-clock bound the core asks for has to be enforced
+// here, with AbortController (also built into RN). An aborted request rejects,
+// which the core already classifies as a transport failure and retries.
 export function createFetchHttp() {
   return {
-    post(url, body) {
-      return fetch(url, {
+    post(url, body, options) {
+      const timeout = options && options.timeout;
+      const controller =
+        typeof AbortController === 'function' && timeout > 0 ? new AbortController() : null;
+      const timer = controller ? setTimeout(() => controller.abort(), timeout) : null;
+      const clear = () => {
+        if (timer) clearTimeout(timer);
+      };
+
+      const init = {
         method: 'POST',
         headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
-      }).then((res) =>
-        res
-          .json()
-          .catch(() => ({}))
-          .then((data) => ({ status: res.status, data }))
-      );
+      };
+      if (controller) init.signal = controller.signal;
+
+      return fetch(url, init)
+        .then((res) =>
+          res
+            .json()
+            .catch(() => ({}))
+            .then((data) => ({ status: res.status, data }))
+        )
+        .then(
+          (result) => {
+            clear();
+            return result;
+          },
+          (err) => {
+            clear();
+            throw err;
+          }
+        );
     },
   };
 }

--- a/src/magic/adapters/reactNative.js
+++ b/src/magic/adapters/reactNative.js
@@ -1,0 +1,46 @@
+'use strict';
+
+import {
+  EVENT_NAMES,
+  getEmitter,
+  getNativeModule,
+} from '../../internal/checkoutSession';
+
+// Magic subscribes with per-call handles rather than reusing
+// removeSubscriptions(), because that helper clears listeners globally and
+// would tear down a concurrent open() as a side effect.
+export function createReactNativeHost() {
+  return {
+    open(options) {
+      getNativeModule().open(options);
+    },
+    subscribe({ onSuccess, onError }) {
+      const emitter = getEmitter();
+      const successSub = emitter.addListener(EVENT_NAMES.SUCCESS, onSuccess);
+      const errorSub = emitter.addListener(EVENT_NAMES.ERROR, onError);
+      return () => {
+        successSub.remove();
+        errorSub.remove();
+      };
+    },
+  };
+}
+
+// React Native ships fetch, so this adds no dependency. It exists as a port so
+// the core can be tested without a network and reused by a non-RN wrapper.
+export function createFetchHttp() {
+  return {
+    post(url, body) {
+      return fetch(url, {
+        method: 'POST',
+        headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }).then((res) =>
+        res
+          .json()
+          .catch(() => ({}))
+          .then((data) => ({ status: res.status, data }))
+      );
+    },
+  };
+}

--- a/src/magic/core/__tests__/client.test.js
+++ b/src/magic/core/__tests__/client.test.js
@@ -24,7 +24,11 @@ describe('init', () => {
       cart_id: 'gid://shopify/Cart/c1-a',
       storefront_access_token: 't',
     });
-    expect(res).toEqual({ order_id: 'order_1', experiments: { a: 'b' } });
+    expect(res).toEqual({
+      order_id: 'order_1',
+      experiments: { a: 'b' },
+      poll_budget_ms: 8000,
+    });
     expect(http.calls[0].url).toContain('/magic/shopify/init?key_id=k');
     expect(http.calls[0].body).toEqual({
       cart_id: 'gid://shopify/Cart/c1-a',
@@ -52,6 +56,29 @@ describe('init', () => {
     const http = makeHttp([{ status: 200, data: { experiments: {} } }]);
     await expect(createClient(http).init('k', {})).rejects.toMatchObject({
       reason: 'missing_order_id',
+    });
+  });
+
+  it('should carry a server-supplied budget then return it alongside the order id', async () => {
+    const http = makeHttp([{ status: 200, data: { order_id: 'order_1', poll_budget_ms: 3000 } }]);
+    const res = await createClient(http).init('k', {});
+    expect(res.poll_budget_ms).toBe(3000);
+  });
+
+  const untrustedBudgets = {
+    'should ignore a missing budget then fall back to the compiled default': undefined,
+    'should ignore a non-numeric budget then fall back to the compiled default': '3000',
+    'should ignore a null budget then fall back to the compiled default': null,
+    'should ignore an absurdly large budget then fall back to the compiled default': 900000,
+    'should ignore a sub-round-trip budget then fall back to the compiled default': 1,
+    'should ignore a negative budget then fall back to the compiled default': -1,
+  };
+
+  Object.entries(untrustedBudgets).forEach(([name, poll_budget_ms]) => {
+    it(name, async () => {
+      const http = makeHttp([{ status: 200, data: { order_id: 'order_1', poll_budget_ms } }]);
+      const res = await createClient(http).init('k', {});
+      expect(res.poll_budget_ms).toBe(8000);
     });
   });
 });
@@ -104,6 +131,65 @@ describe('complete', () => {
     await expect(
       createClient(http).complete('k', undefined, handle, () => 0)
     ).rejects.toMatchObject({ code: MAGIC_ERROR_CODES.COMPLETE_FAILED, reason: 'http_400' });
+  });
+
+  // MB1. The fake below stands in for a hung socket: it settles ONLY if the
+  // caller handed it a positive timeout. Against an unbounded client.post this
+  // test does not fail an assertion, it never returns -- which is exactly the
+  // production outcome, a promise left pending over a captured payment.
+  it('should bound a hung attempt then return pending inside the budget', async () => {
+    const seen = [];
+    const http = {
+      post: jest.fn((url, body, options) => {
+        seen.push(options);
+        return new Promise((resolve, reject) => {
+          if (options && options.timeout > 0) {
+            setTimeout(() => reject(new Error('aborted')), options.timeout);
+          }
+        });
+      }),
+    };
+
+    const res = await createClient(http).complete('k', undefined, handle, () => Date.now(), 100);
+
+    expect(seen[0].timeout).toBeGreaterThan(0);
+    expect(seen[0].timeout).toBeLessThanOrEqual(100);
+    expect(res.status).toBe('pending');
+  });
+
+  it('should shrink the per-attempt timeout then never let one attempt outlive the budget', async () => {
+    const seen = [];
+    const http = {
+      post: jest.fn((url, body, options) => {
+        seen.push(options.timeout);
+        return Promise.resolve({ status: 500, data: {} });
+      }),
+    };
+    let clock = 0;
+    await createClient(http).complete('k', undefined, handle, () => (clock += 2000), 8000);
+
+    expect(seen.length).toBeGreaterThan(1);
+    seen.forEach((timeout) => expect(timeout).toBeLessThanOrEqual(8000));
+    expect(seen[1]).toBeLessThan(seen[0]);
+  });
+
+  it('should honour a server-supplied budget then stop retrying once it elapses', async () => {
+    const http = makeHttp([
+      { status: 500, data: {} },
+      { status: 500, data: {} },
+      { status: 500, data: {} },
+    ]);
+    let clock = 0;
+    const res = await createClient(http).complete(
+      'k',
+      undefined,
+      handle,
+      () => (clock += 600),
+      1000
+    );
+    expect(res.status).toBe('pending');
+    // A 1s budget must not buy the 8s default's worth of attempts.
+    expect(http.post).toHaveBeenCalledTimes(1);
   });
 
   it('should use the variant route then post to checkouts shopify complete', async () => {

--- a/src/magic/core/__tests__/client.test.js
+++ b/src/magic/core/__tests__/client.test.js
@@ -1,0 +1,119 @@
+const { createClient } = require('../client');
+const { MAGIC_ERROR_CODES } = require('../errors');
+
+function makeHttp(responses) {
+  const calls = [];
+  const queue = responses.slice();
+  return {
+    calls,
+    post: jest.fn((url, body) => {
+      calls.push({ url, body });
+      const next = queue.shift();
+      if (next instanceof Error) return Promise.reject(next);
+      return Promise.resolve(next);
+    }),
+  };
+}
+
+describe('init', () => {
+  it('should post the cart id and token then return order id and experiments', async () => {
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1', experiments: { a: 'b' } } },
+    ]);
+    const res = await createClient(http).init('k', {
+      cart_id: 'gid://shopify/Cart/c1-a',
+      storefront_access_token: 't',
+    });
+    expect(res).toEqual({ order_id: 'order_1', experiments: { a: 'b' } });
+    expect(http.calls[0].url).toContain('/magic/shopify/init?key_id=k');
+    expect(http.calls[0].body).toEqual({
+      cart_id: 'gid://shopify/Cart/c1-a',
+      storefront_access_token: 't',
+    });
+  });
+
+  it('should reject with ORDER_CREATE_FAILED then set reason http_400 on a 4xx', async () => {
+    const http = makeHttp([{ status: 400, data: { error: 'bad' } }]);
+    await expect(createClient(http).init('k', {})).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.ORDER_CREATE_FAILED,
+      reason: 'http_400',
+    });
+  });
+
+  it('should reject with ORDER_CREATE_FAILED then set reason network on a transport error', async () => {
+    const http = makeHttp([new Error('offline')]);
+    await expect(createClient(http).init('k', {})).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.ORDER_CREATE_FAILED,
+      reason: 'network',
+    });
+  });
+
+  it('should reject with ORDER_CREATE_FAILED then set reason missing_order_id when absent', async () => {
+    const http = makeHttp([{ status: 200, data: { experiments: {} } }]);
+    await expect(createClient(http).init('k', {})).rejects.toMatchObject({
+      reason: 'missing_order_id',
+    });
+  });
+});
+
+describe('complete', () => {
+  const handle = {
+    razorpay_order_id: 'order_1',
+    razorpay_payment_id: 'pay_1',
+    razorpay_signature: 'sig',
+    key: 'k',
+  };
+
+  it('should post the handle then return placed on 200', async () => {
+    const http = makeHttp([{ status: 200, data: { order_id: 'shop_1' } }]);
+    const res = await createClient(http).complete('k', undefined, handle, () => 0);
+    expect(res.status).toBe('placed');
+    expect(http.calls[0].body).toEqual(handle);
+  });
+
+  it('should treat a 422 already placed then return pending', async () => {
+    const http = makeHttp([{ status: 422, data: { error: { code: 'ALREADY_PLACED' } } }]);
+    const res = await createClient(http).complete('k', undefined, handle, () => 0);
+    expect(res.status).toBe('pending');
+  });
+
+  it('should retry a 5xx then return placed when the retry succeeds', async () => {
+    const http = makeHttp([
+      { status: 500, data: {} },
+      { status: 200, data: { order_id: 'shop_1' } },
+    ]);
+    let clock = 0;
+    const res = await createClient(http).complete('k', undefined, handle, () => (clock += 100));
+    expect(res.status).toBe('placed');
+    expect(http.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('should exhaust the budget then return pending without throwing', async () => {
+    const http = makeHttp([
+      { status: 500, data: {} },
+      { status: 500, data: {} },
+      { status: 500, data: {} },
+    ]);
+    let clock = 0;
+    const res = await createClient(http).complete('k', undefined, handle, () => (clock += 5000));
+    expect(res.status).toBe('pending');
+  });
+
+  it('should reject with COMPLETE_FAILED then set reason http_400 on a non-retryable 4xx', async () => {
+    const http = makeHttp([{ status: 400, data: { error: { code: 'BAD_SIGNATURE' } } }]);
+    await expect(
+      createClient(http).complete('k', undefined, handle, () => 0)
+    ).rejects.toMatchObject({ code: MAGIC_ERROR_CODES.COMPLETE_FAILED, reason: 'http_400' });
+  });
+
+  it('should use the variant route then post to checkouts shopify complete', async () => {
+    const http = makeHttp([{ status: 200, data: {} }]);
+    await createClient(http).complete(
+      'k',
+      { shopify_pre_payment_guardrail: 'variant_on' },
+      handle,
+      () => 0
+    );
+    expect(http.calls[0].url).toContain('/checkouts/shopify/complete');
+  });
+});

--- a/src/magic/core/__tests__/endpoints.test.js
+++ b/src/magic/core/__tests__/endpoints.test.js
@@ -1,0 +1,26 @@
+const { initUrl, completeUrl, BASE_URL } = require('../endpoints');
+
+describe('endpoints', () => {
+  it('should build the init url then include the encoded key', () => {
+    expect(initUrl('rzp_test_a b')).toBe(`${BASE_URL}/magic/shopify/init?key_id=rzp_test_a%20b`);
+  });
+
+  const completeCases = {
+    'should use the monolith route then return 1cc path when the experiment is absent': [
+      undefined,
+      `${BASE_URL}/1cc/shopify/complete?key_id=k`,
+    ],
+    'should use the monolith route then return 1cc path when the variant is off': [
+      { shopify_pre_payment_guardrail: 'variant_off' },
+      `${BASE_URL}/1cc/shopify/complete?key_id=k`,
+    ],
+    'should use the MCS route then return checkouts path when the variant is on': [
+      { shopify_pre_payment_guardrail: 'variant_on' },
+      `${BASE_URL}/checkouts/shopify/complete?key_id=k`,
+    ],
+  };
+
+  Object.entries(completeCases).forEach(([name, [experiments, expected]]) => {
+    it(name, () => expect(completeUrl('k', experiments)).toBe(expected));
+  });
+});

--- a/src/magic/core/__tests__/errors.test.js
+++ b/src/magic/core/__tests__/errors.test.js
@@ -1,0 +1,32 @@
+const { MagicCheckoutError, MAGIC_ERROR_CODES } = require('../errors');
+
+describe('MagicCheckoutError', () => {
+  it('should build an error then expose code reason and details', () => {
+    const err = new MagicCheckoutError(MAGIC_ERROR_CODES.ORDER_CREATE_FAILED, 'network', {
+      status: 0,
+    });
+    expect(err.code).toBe('MAGIC_ORDER_CREATE_FAILED');
+    expect(err.reason).toBe('network');
+    expect(err.details).toEqual({ status: 0 });
+  });
+
+  it('should extend Error then remain instanceof Error', () => {
+    const err = new MagicCheckoutError(MAGIC_ERROR_CODES.PAYMENT_FAILED, 'user_cancelled');
+    expect(err instanceof Error).toBe(true);
+    expect(err.name).toBe('MagicCheckoutError');
+  });
+
+  it('should default details then return an empty object', () => {
+    expect(new MagicCheckoutError(MAGIC_ERROR_CODES.INVALID_OPTIONS, 'missing_key').details).toEqual({});
+  });
+
+  it('should expose every documented code then match the taxonomy', () => {
+    expect(MAGIC_ERROR_CODES).toEqual({
+      ORDER_CREATE_FAILED: 'MAGIC_ORDER_CREATE_FAILED',
+      CHECKOUT_CANCELLED: 'MAGIC_CHECKOUT_CANCELLED',
+      PAYMENT_FAILED: 'MAGIC_PAYMENT_FAILED',
+      COMPLETE_FAILED: 'MAGIC_COMPLETE_FAILED',
+      INVALID_OPTIONS: 'MAGIC_INVALID_OPTIONS',
+    });
+  });
+});

--- a/src/magic/core/__tests__/openMagicCheckout.test.js
+++ b/src/magic/core/__tests__/openMagicCheckout.test.js
@@ -1,4 +1,5 @@
 const { createMagicCheckout } = require('../index');
+const { makeOpenMagicCheckout } = require('../openMagicCheckout');
 const { MAGIC_ERROR_CODES } = require('../errors');
 
 function makeHost() {
@@ -74,6 +75,21 @@ describe('openMagicCheckout', () => {
     });
   });
 
+  it('should surface the shopify total then include total_amount in the resolved result', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1' } },
+      { status: 200, data: { order_id: 'shop_1', total_amount: 49900 } },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+
+    await expect(promise).resolves.toMatchObject({ total_amount: 49900 });
+  });
+
   it('should never send cart data to the modal then pass only key and order id', async () => {
     const host = makeHost();
     const http = makeHttp([
@@ -106,6 +122,7 @@ describe('openMagicCheckout', () => {
       code: MAGIC_ERROR_CODES.CHECKOUT_CANCELLED,
     });
     expect(http.post).toHaveBeenCalledTimes(1);
+    expect(host.unsubscribed).toBe(true);
   });
 
   it('should reject as payment failed then pass the native code through', async () => {
@@ -121,6 +138,7 @@ describe('openMagicCheckout', () => {
       code: MAGIC_ERROR_CODES.PAYMENT_FAILED,
       details: { code: 2, description: 'network' },
     });
+    expect(host.unsubscribed).toBe(true);
   });
 
   it('should reject before opening the modal then never call host open on phase one failure', async () => {
@@ -172,6 +190,7 @@ describe('openMagicCheckout', () => {
         },
       },
     });
+    expect(host.unsubscribed).toBe(true);
   });
 
   it('should unsubscribe then release the listener on every terminal path', async () => {
@@ -190,6 +209,121 @@ describe('openMagicCheckout', () => {
     expect(host.unsubscribed).toBe(true);
   });
 
+  it('should reject as complete failed then attach a recoverable handle when the success payload is null', async () => {
+    const host = makeHost();
+    const http = makeHttp([{ status: 200, data: { order_id: 'order_1' } }]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(null);
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.COMPLETE_FAILED,
+      reason: 'invalid_success_payload',
+      details: {
+        handle: { razorpay_order_id: 'order_1', key: 'rzp_test_k' },
+      },
+    });
+    // A malformed payload must be rejected before phase 3 ever runs -- only
+    // the phase-1 init call should have gone out.
+    expect(http.post).toHaveBeenCalledTimes(1);
+    expect(host.unsubscribed).toBe(true);
+  });
+
+  it('should reject as complete failed then attach a recoverable handle when the payment id is blank', async () => {
+    const host = makeHost();
+    const http = makeHttp([{ status: 200, data: { order_id: 'order_1' } }]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess({ razorpay_payment_id: '', razorpay_order_id: 'order_1' });
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.COMPLETE_FAILED,
+      reason: 'invalid_success_payload',
+    });
+    expect(http.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore a late error after success then still resolve the placed order', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1' } },
+      { status: 200, data: { order_id: 'shop_1' } },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    // Fire success, then -- before phase 3 has a chance to resolve -- fire a
+    // stray late error on the same listener. The first event must win.
+    host.handlers.onSuccess(SUCCESS);
+    host.handlers.onError({ code: 2, description: 'late' });
+
+    await expect(promise).resolves.toMatchObject({ status: 'placed', order_id: 'shop_1' });
+    expect(http.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('should ignore a late success after dismissal then never call complete', async () => {
+    const host = makeHost();
+    const http = makeHttp([{ status: 200, data: { order_id: 'order_1' } }]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onError({ code: 0, description: 'cancelled' });
+    host.handlers.onSuccess(SUCCESS);
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.CHECKOUT_CANCELLED,
+    });
+    // The late success must never reach phase 3 -- only the phase-1 init
+    // call should have gone out.
+    expect(http.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject then release the listener when host.open throws synchronously', async () => {
+    const host = makeHost();
+    host.open = jest.fn(() => {
+      throw new Error('modal boom');
+    });
+    const http = makeHttp([{ status: 200, data: { order_id: 'order_1' } }]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    await expect(sdk.openMagicCheckout(OPTIONS)).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.PAYMENT_FAILED,
+      reason: 'host_open_threw',
+    });
+    expect(host.unsubscribed).toBe(true);
+  });
+
+  it('should normalise a non-error rejection then still attach the handle', async () => {
+    const host = makeHost();
+    const client = {
+      init: jest.fn(() => Promise.resolve({ order_id: 'order_1', experiments: {} })),
+      complete: jest.fn(() => Promise.reject('a plain string rejection')),
+    };
+    const openMagicCheckout = makeOpenMagicCheckout({ host, client });
+
+    const promise = openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.COMPLETE_FAILED,
+      details: {
+        handle: {
+          razorpay_order_id: 'order_1',
+          razorpay_payment_id: 'pay_1',
+          razorpay_signature: 'sig_1',
+          key: 'rzp_test_k',
+        },
+      },
+    });
+  });
+
   const invalid = {
     'should reject when key is missing then report missing_key': [
       { storefront_access_token: 't', cart_id: 'c' },
@@ -205,6 +339,14 @@ describe('openMagicCheckout', () => {
     ],
     'should reject a cart object then report cart_not_allowed': [
       { key: 'k', cart_id: 'c', storefront_access_token: 't', shopify_cart: { items: [] } },
+      'cart_not_allowed',
+    ],
+    'should reject a bare cart object then report cart_not_allowed': [
+      { key: 'k', cart_id: 'c', storefront_access_token: 't', cart: { items: [] } },
+      'cart_not_allowed',
+    ],
+    'should reject line items then report cart_not_allowed': [
+      { key: 'k', cart_id: 'c', storefront_access_token: 't', line_items: [{ id: 1 }] },
       'cart_not_allowed',
     ],
   };

--- a/src/magic/core/__tests__/openMagicCheckout.test.js
+++ b/src/magic/core/__tests__/openMagicCheckout.test.js
@@ -1,0 +1,224 @@
+const { createMagicCheckout } = require('../index');
+const { MAGIC_ERROR_CODES } = require('../errors');
+
+function makeHost() {
+  const host = {
+    opened: [],
+    handlers: null,
+    unsubscribed: false,
+    open: jest.fn((options) => host.opened.push(options)),
+    subscribe: jest.fn((handlers) => {
+      host.handlers = handlers;
+      return () => {
+        host.unsubscribed = true;
+      };
+    }),
+  };
+  return host;
+}
+
+function makeHttp(responses) {
+  const queue = responses.slice();
+  const calls = [];
+  return {
+    calls,
+    post: jest.fn((url, body) => {
+      calls.push({ url, body });
+      const next = queue.shift();
+      if (next instanceof Error) return Promise.reject(next);
+      return Promise.resolve(next);
+    }),
+  };
+}
+
+const OPTIONS = {
+  key: 'rzp_test_k',
+  storefront_access_token: 'sf-token',
+  cart_id: 'gid://shopify/Cart/c1-abc',
+};
+
+const SUCCESS = {
+  razorpay_payment_id: 'pay_1',
+  razorpay_order_id: 'order_1',
+  razorpay_signature: 'sig_1',
+};
+
+function flush() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('openMagicCheckout', () => {
+  it('should complete every phase then resolve with the shopify order', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1', experiments: {} } },
+      { status: 200, data: { order_id: 'shop_1', order_status_url: 'https://s/o/1' } },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+
+    expect(host.opened[0]).toEqual({
+      key: 'rzp_test_k',
+      order_id: 'order_1',
+      one_click_checkout: true,
+    });
+
+    host.handlers.onSuccess(SUCCESS);
+    await expect(promise).resolves.toMatchObject({
+      order_id: 'shop_1',
+      order_status_url: 'https://s/o/1',
+      payment_id: 'pay_1',
+      status: 'placed',
+    });
+  });
+
+  it('should never send cart data to the modal then pass only key and order id', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1' } },
+      { status: 200, data: {} },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+    await promise;
+
+    expect(Object.keys(host.opened[0]).sort()).toEqual([
+      'key',
+      'one_click_checkout',
+      'order_id',
+    ]);
+  });
+
+  it('should not call complete when the user dismisses then reject as cancelled', async () => {
+    const host = makeHost();
+    const http = makeHttp([{ status: 200, data: { order_id: 'order_1' } }]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onError({ code: 0, description: 'cancelled' });
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.CHECKOUT_CANCELLED,
+    });
+    expect(http.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject as payment failed then pass the native code through', async () => {
+    const host = makeHost();
+    const http = makeHttp([{ status: 200, data: { order_id: 'order_1' } }]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onError({ code: 2, description: 'network' });
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.PAYMENT_FAILED,
+      details: { code: 2, description: 'network' },
+    });
+  });
+
+  it('should reject before opening the modal then never call host open on phase one failure', async () => {
+    const host = makeHost();
+    const http = makeHttp([{ status: 500, data: {} }]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    await expect(sdk.openMagicCheckout(OPTIONS)).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.ORDER_CREATE_FAILED,
+    });
+    expect(host.open).not.toHaveBeenCalled();
+  });
+
+  it('should resolve as pending then report status pending when MCS defers', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1' } },
+      { status: 422, data: { error: { code: 'DELEGATED_TO_SQS' } } },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+
+    await expect(promise).resolves.toMatchObject({ status: 'pending', payment_id: 'pay_1' });
+  });
+
+  it('should attach the handle then include it on every phase three rejection', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1' } },
+      { status: 400, data: { error: { code: 'BAD_SIGNATURE' } } },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.COMPLETE_FAILED,
+      details: {
+        handle: {
+          razorpay_order_id: 'order_1',
+          razorpay_payment_id: 'pay_1',
+          razorpay_signature: 'sig_1',
+          key: 'rzp_test_k',
+        },
+      },
+    });
+  });
+
+  it('should unsubscribe then release the listener on every terminal path', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1' } },
+      { status: 200, data: {} },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+    await promise;
+
+    expect(host.unsubscribed).toBe(true);
+  });
+
+  const invalid = {
+    'should reject when key is missing then report missing_key': [
+      { storefront_access_token: 't', cart_id: 'c' },
+      'missing_key',
+    ],
+    'should reject when cart_id is missing then report missing_cart_id': [
+      { key: 'k', storefront_access_token: 't' },
+      'missing_cart_id',
+    ],
+    'should reject when the storefront token is missing then report missing_storefront_access_token': [
+      { key: 'k', cart_id: 'c' },
+      'missing_storefront_access_token',
+    ],
+    'should reject a cart object then report cart_not_allowed': [
+      { key: 'k', cart_id: 'c', storefront_access_token: 't', shopify_cart: { items: [] } },
+      'cart_not_allowed',
+    ],
+  };
+
+  Object.entries(invalid).forEach(([name, [options, reason]]) => {
+    it(name, async () => {
+      const host = makeHost();
+      const http = makeHttp([]);
+      const sdk = createMagicCheckout({ host, http, now: () => 0 });
+      await expect(sdk.openMagicCheckout(options)).rejects.toMatchObject({
+        code: MAGIC_ERROR_CODES.INVALID_OPTIONS,
+        reason,
+      });
+      expect(http.post).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/magic/core/__tests__/openMagicCheckout.test.js
+++ b/src/magic/core/__tests__/openMagicCheckout.test.js
@@ -23,8 +23,8 @@ function makeHttp(responses) {
   const calls = [];
   return {
     calls,
-    post: jest.fn((url, body) => {
-      calls.push({ url, body });
+    post: jest.fn((url, body, options) => {
+      calls.push({ url, body, options });
       const next = queue.shift();
       if (next instanceof Error) return Promise.reject(next);
       return Promise.resolve(next);
@@ -72,6 +72,31 @@ describe('openMagicCheckout', () => {
       order_status_url: 'https://s/o/1',
       payment_id: 'pay_1',
       status: 'placed',
+    });
+  });
+
+  // SF1. This is the request that turns a captured payment into a Shopify
+  // order. If `key` or `razorpay_signature` ever stops reaching the wire the
+  // backend rejects every confirmation, so the body is pinned field by field
+  // rather than through the client boundary alone.
+  it('should post the handle to complete then send order id payment id signature and key', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1', experiments: {} } },
+      { status: 200, data: { order_id: 'shop_1' } },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+    await promise;
+
+    expect(http.calls[1].body).toEqual({
+      razorpay_order_id: 'order_1',
+      razorpay_payment_id: 'pay_1',
+      razorpay_signature: 'sig_1',
+      key: 'rzp_test_k',
     });
   });
 
@@ -313,6 +338,7 @@ describe('openMagicCheckout', () => {
 
     await expect(promise).rejects.toMatchObject({
       code: MAGIC_ERROR_CODES.COMPLETE_FAILED,
+      reason: 'non_error_rejection',
       details: {
         handle: {
           razorpay_order_id: 'order_1',
@@ -322,6 +348,47 @@ describe('openMagicCheckout', () => {
         },
       },
     });
+  });
+
+  // SF4. An exception thrown inside our own SDK and a client that rejected
+  // with a bare string are different incidents; `reason` is the field they get
+  // split by, so it must not collapse them into one bucket.
+  it('should distinguish a thrown Error then report its type as the reason', async () => {
+    const host = makeHost();
+    const client = {
+      init: jest.fn(() => Promise.resolve({ order_id: 'order_1', experiments: {} })),
+      complete: jest.fn(() => Promise.reject(new TypeError('x is not a function'))),
+    };
+    const openMagicCheckout = makeOpenMagicCheckout({ host, client });
+
+    const promise = openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+
+    await expect(promise).rejects.toMatchObject({
+      code: MAGIC_ERROR_CODES.COMPLETE_FAILED,
+      reason: 'unexpected_TypeError',
+      details: {
+        original: 'x is not a function',
+        handle: { razorpay_payment_id: 'pay_1', key: 'rzp_test_k' },
+      },
+    });
+  });
+
+  it('should pass the server-tuned budget through then hand it to complete', async () => {
+    const host = makeHost();
+    const http = makeHttp([
+      { status: 200, data: { order_id: 'order_1', poll_budget_ms: 3000 } },
+      { status: 200, data: {} },
+    ]);
+    const sdk = createMagicCheckout({ host, http, now: () => 0 });
+
+    const promise = sdk.openMagicCheckout(OPTIONS);
+    await flush();
+    host.handlers.onSuccess(SUCCESS);
+    await promise;
+
+    expect(http.calls[1].options.timeout).toBeLessThanOrEqual(3000);
   });
 
   const invalid = {

--- a/src/magic/core/__tests__/purity.test.js
+++ b/src/magic/core/__tests__/purity.test.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+const CORE = path.resolve(__dirname, '..');
+
+function coreSourceFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === '__tests__') return [];
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return coreSourceFiles(full);
+    return entry.name.endsWith('.js') ? [full] : [];
+  });
+}
+
+describe('core purity', () => {
+  it('should keep the core platform-neutral then import no react-native', () => {
+    const offenders = coreSourceFiles(CORE).filter((file) =>
+      /from\s+['"]react-native['"]|require\(['"]react-native['"]\)/.test(
+        fs.readFileSync(file, 'utf8')
+      )
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/magic/core/client.js
+++ b/src/magic/core/client.js
@@ -3,7 +3,7 @@
 import {
   initUrl,
   completeUrl,
-  POLL_BUDGET_MS,
+  resolvePollBudgetMs,
   BACKOFF_INITIAL_MS,
   BACKOFF_CAP_MS,
 } from './endpoints';
@@ -53,22 +53,35 @@ export function createClient(http) {
         {}
       );
     }
-    return { order_id: data.order_id, experiments: data.experiments };
+    return {
+      order_id: data.order_id,
+      experiments: data.experiments,
+      poll_budget_ms: resolvePollBudgetMs(data.poll_budget_ms),
+    };
   }
 
   // Confirms MCS RECEIVED the request; it does not wait for the Shopify order.
   // Once MCS has it, the mutex, the 24h placed-marker and the SQS worker own
   // the outcome, so the client waiting longer changes nothing a shopper sees.
-  async function complete(key, experiments, handle, now) {
+  async function complete(key, experiments, handle, now, budgetMs) {
     const url = completeUrl(key, experiments);
+    const budget = resolvePollBudgetMs(budgetMs);
     const started = now();
     let attempt = 0;
 
     for (;;) {
+      // The budget has to bound the request itself, not just the gaps between
+      // attempts. By this point a payment has been captured, and the transports
+      // we run on (RN's fetch, and OkHttp under it) impose no read timeout of
+      // their own -- so an unbounded attempt would leave the caller holding a
+      // promise that never settles over money that has already moved.
+      const remaining = budget - (now() - started);
+      if (remaining <= 0) return { status: 'pending', data: {} };
+
       let res;
       let transportError = null;
       try {
-        res = await http.post(url, handle);
+        res = await http.post(url, handle, { timeout: remaining });
       } catch (e) {
         transportError = e;
       }
@@ -91,7 +104,7 @@ export function createClient(http) {
 
       // 5xx or transport failure: retry is safe because MCS is idempotent
       // (mutex + 24h marker + Shopify search fallback).
-      if (now() - started >= POLL_BUDGET_MS) {
+      if (now() - started >= budget) {
         return { status: 'pending', data: {} };
       }
       await sleep(backoffFor(attempt));

--- a/src/magic/core/client.js
+++ b/src/magic/core/client.js
@@ -1,0 +1,103 @@
+'use strict';
+
+import {
+  initUrl,
+  completeUrl,
+  POLL_BUDGET_MS,
+  BACKOFF_INITIAL_MS,
+  BACKOFF_CAP_MS,
+} from './endpoints';
+import { MagicCheckoutError, MAGIC_ERROR_CODES } from './errors';
+
+// MCS signals "I have the request, my worker owns placement from here" through
+// these. They are NOT failures: retrying past them buys nothing, and surfacing
+// them as errors would tell a shopper their order failed when it has not.
+const PENDING_CODES = ['DELEGATED_TO_SQS', 'ALREADY_PLACED', 'RETRY_FAILED'];
+
+function errorCodeOf(data) {
+  if (!data) return undefined;
+  if (data.error && typeof data.error.code === 'string') return data.error.code;
+  return typeof data.code === 'string' ? data.code : undefined;
+}
+
+function backoffFor(attempt) {
+  return Math.min(BACKOFF_INITIAL_MS * Math.pow(2, attempt), BACKOFF_CAP_MS);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function createClient(http) {
+  async function init(key, body) {
+    let res;
+    try {
+      res = await http.post(initUrl(key), body);
+    } catch (e) {
+      throw new MagicCheckoutError(MAGIC_ERROR_CODES.ORDER_CREATE_FAILED, 'network', {
+        message: e && e.message,
+      });
+    }
+    if (res.status !== 200) {
+      throw new MagicCheckoutError(
+        MAGIC_ERROR_CODES.ORDER_CREATE_FAILED,
+        `http_${res.status}`,
+        { status: res.status }
+      );
+    }
+    const data = res.data || {};
+    if (!data.order_id) {
+      throw new MagicCheckoutError(
+        MAGIC_ERROR_CODES.ORDER_CREATE_FAILED,
+        'missing_order_id',
+        {}
+      );
+    }
+    return { order_id: data.order_id, experiments: data.experiments };
+  }
+
+  // Confirms MCS RECEIVED the request; it does not wait for the Shopify order.
+  // Once MCS has it, the mutex, the 24h placed-marker and the SQS worker own
+  // the outcome, so the client waiting longer changes nothing a shopper sees.
+  async function complete(key, experiments, handle, now) {
+    const url = completeUrl(key, experiments);
+    const started = now();
+    let attempt = 0;
+
+    for (;;) {
+      let res;
+      let transportError = null;
+      try {
+        res = await http.post(url, handle);
+      } catch (e) {
+        transportError = e;
+      }
+
+      if (!transportError) {
+        if (res.status === 200) {
+          return { status: 'placed', data: res.data || {} };
+        }
+        if (PENDING_CODES.indexOf(errorCodeOf(res.data)) !== -1) {
+          return { status: 'pending', data: res.data || {} };
+        }
+        if (res.status < 500) {
+          throw new MagicCheckoutError(
+            MAGIC_ERROR_CODES.COMPLETE_FAILED,
+            `http_${res.status}`,
+            { status: res.status, handle }
+          );
+        }
+      }
+
+      // 5xx or transport failure: retry is safe because MCS is idempotent
+      // (mutex + 24h marker + Shopify search fallback).
+      if (now() - started >= POLL_BUDGET_MS) {
+        return { status: 'pending', data: {} };
+      }
+      await sleep(backoffFor(attempt));
+      attempt += 1;
+    }
+  }
+
+  return { init, complete };
+}

--- a/src/magic/core/endpoints.js
+++ b/src/magic/core/endpoints.js
@@ -10,6 +10,24 @@ export const POLL_BUDGET_MS = 8000;
 export const BACKOFF_INITIAL_MS = 500;
 export const BACKOFF_CAP_MS = 2000;
 
+// Sane band for a server-supplied budget. Below the floor phase 3 could not
+// complete a round trip and every order would report pending; above the ceiling
+// the native SDK is left waiting on the WebView callback for longer than a
+// shopper will tolerate.
+const MIN_POLL_BUDGET_MS = 100;
+const MAX_POLL_BUDGET_MS = 60000;
+
+// A merchant's app binary is pinned behind app-store review, so the budget has
+// to be movable from the phase-1 response rather than living only in a constant
+// we cannot re-deploy. A missing, non-numeric or out-of-band value must never be
+// able to make phase 3 misbehave, so anything we do not trust falls back to the
+// compiled default.
+export function resolvePollBudgetMs(value) {
+  if (typeof value !== 'number' || !isFinite(value)) return POLL_BUDGET_MS;
+  if (value < MIN_POLL_BUDGET_MS || value > MAX_POLL_BUDGET_MS) return POLL_BUDGET_MS;
+  return value;
+}
+
 const PRE_PAYMENT_GUARDRAIL = 'shopify_pre_payment_guardrail';
 
 export function initUrl(key) {

--- a/src/magic/core/endpoints.js
+++ b/src/magic/core/endpoints.js
@@ -1,0 +1,29 @@
+'use strict';
+
+export const BASE_URL = 'https://api.razorpay.com/v1';
+
+// The SDK's own waiting budget for phase 3 — not a money timeout. Exhausting it
+// does NOT mean the order failed: MCS's worker keeps retrying for ~15 minutes
+// after it has the request. Kept short deliberately so the native SDK is never
+// left waiting on the WebView completion callback.
+export const POLL_BUDGET_MS = 8000;
+export const BACKOFF_INITIAL_MS = 500;
+export const BACKOFF_CAP_MS = 2000;
+
+const PRE_PAYMENT_GUARDRAIL = 'shopify_pre_payment_guardrail';
+
+export function initUrl(key) {
+  return `${BASE_URL}/magic/shopify/init?key_id=${encodeURIComponent(key)}`;
+}
+
+// Mirrors magic-plugins post-checkout.ts:162-166. The experiment value arrives
+// in the phase-1 response, so which endpoint a shipped binary calls stays
+// server-tunable — a merchant moved into the variant cohort does not need an
+// app update to keep placing orders.
+export function completeUrl(key, experiments) {
+  const path =
+    experiments && experiments[PRE_PAYMENT_GUARDRAIL] === 'variant_on'
+      ? 'checkouts/shopify/complete'
+      : '1cc/shopify/complete';
+  return `${BASE_URL}/${path}?key_id=${encodeURIComponent(key)}`;
+}

--- a/src/magic/core/errors.js
+++ b/src/magic/core/errors.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// ACTION_STATUS names. The specific cause goes in `reason`, never in the code,
+// so one Coralogix query over MAGIC_* yields success-vs-failure counts split by
+// reason instead of exploding into a code per failure mode.
+export const MAGIC_ERROR_CODES = {
+  ORDER_CREATE_FAILED: 'MAGIC_ORDER_CREATE_FAILED',
+  CHECKOUT_CANCELLED: 'MAGIC_CHECKOUT_CANCELLED',
+  PAYMENT_FAILED: 'MAGIC_PAYMENT_FAILED',
+  COMPLETE_FAILED: 'MAGIC_COMPLETE_FAILED',
+  INVALID_OPTIONS: 'MAGIC_INVALID_OPTIONS',
+};
+
+export class MagicCheckoutError extends Error {
+  constructor(code, reason, details) {
+    super(`${code}: ${reason}`);
+    this.name = 'MagicCheckoutError';
+    this.code = code;
+    this.reason = reason;
+    this.details = details || {};
+  }
+}

--- a/src/magic/core/index.js
+++ b/src/magic/core/index.js
@@ -11,8 +11,8 @@ export function createMagicCheckout({ host, http, now }) {
   const rawClient = createClient(http);
   const client = {
     init: rawClient.init,
-    complete: (key, experiments, handle) =>
-      rawClient.complete(key, experiments, handle, clock),
+    complete: (key, experiments, handle, budgetMs) =>
+      rawClient.complete(key, experiments, handle, clock, budgetMs),
   };
   return { openMagicCheckout: makeOpenMagicCheckout({ host, client }) };
 }

--- a/src/magic/core/index.js
+++ b/src/magic/core/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+import { createClient } from './client';
+import { makeOpenMagicCheckout } from './openMagicCheckout';
+
+// `now` is injected so the phase-3 poll budget is testable with a fake clock
+// instead of sleeping in tests. `host` and `http` are ports supplied by the
+// platform-specific caller (RN NativeModules/TurboModule + fetch, in prod).
+export function createMagicCheckout({ host, http, now }) {
+  const clock = now || (() => Date.now());
+  const rawClient = createClient(http);
+  const client = {
+    init: rawClient.init,
+    complete: (key, experiments, handle) =>
+      rawClient.complete(key, experiments, handle, clock),
+  };
+  return { openMagicCheckout: makeOpenMagicCheckout({ host, client }) };
+}

--- a/src/magic/core/openMagicCheckout.js
+++ b/src/magic/core/openMagicCheckout.js
@@ -1,0 +1,98 @@
+'use strict';
+
+import { MagicCheckoutError, MAGIC_ERROR_CODES } from './errors';
+
+const NATIVE_PAYMENT_CANCELED = 0;
+
+// A cart object must never reach us. Prices and line items belong server-side;
+// accepting one here would put amounts in a publicly-readable package and on
+// the wire from a device we do not control. Checked before any network call.
+function validate(options) {
+  const o = options || {};
+  if (!o.key) return 'missing_key';
+  if (!o.cart_id) return 'missing_cart_id';
+  if (!o.storefront_access_token) return 'missing_storefront_access_token';
+  if (o.shopify_cart || o.cart || o.line_items) return 'cart_not_allowed';
+  return null;
+}
+
+export function makeOpenMagicCheckout({ host, client }) {
+  return function openMagicCheckout(options) {
+    const invalidReason = validate(options);
+    if (invalidReason) {
+      return Promise.reject(
+        new MagicCheckoutError(MAGIC_ERROR_CODES.INVALID_OPTIONS, invalidReason, {})
+      );
+    }
+
+    const { key, cart_id, storefront_access_token } = options;
+
+    return client
+      .init(key, { cart_id, storefront_access_token })
+      .then(({ order_id, experiments }) => {
+        return new Promise((resolve, reject) => {
+          let unsubscribe = null;
+          const release = () => {
+            if (unsubscribe) unsubscribe();
+            unsubscribe = null;
+          };
+
+          unsubscribe = host.subscribe({
+            onSuccess: (data) => {
+              // The handle is the only way to recover a captured payment whose
+              // order never got placed, so it is built the instant onSuccess
+              // fires -- never inside a catch -- and threaded through every
+              // phase-3 outcome from here on, success or failure.
+              const handle = {
+                razorpay_order_id: data.razorpay_order_id || order_id,
+                razorpay_payment_id: data.razorpay_payment_id,
+                razorpay_signature: data.razorpay_signature,
+                key,
+              };
+              client
+                .complete(key, experiments, handle)
+                .then((result) => {
+                  release();
+                  resolve({
+                    order_id: result.data.order_id,
+                    order_status_url: result.data.order_status_url,
+                    payment_id: handle.razorpay_payment_id,
+                    status: result.status,
+                  });
+                })
+                .catch((err) => {
+                  release();
+                  // Every phase-3 rejection must carry the handle -- it is the
+                  // on-call recovery path for a payment that was captured but
+                  // never turned into a Shopify order.
+                  err.details = Object.assign({}, err.details, { handle });
+                  reject(err);
+                });
+            },
+            onError: (data) => {
+              // A dismissal means no payment was taken. Phase 3 (`complete`)
+              // must never run here -- there is nothing to place and nothing
+              // to recover, so we release the listener and reject directly.
+              release();
+              const cancelled = data && data.code === NATIVE_PAYMENT_CANCELED;
+              reject(
+                new MagicCheckoutError(
+                  cancelled
+                    ? MAGIC_ERROR_CODES.CHECKOUT_CANCELLED
+                    : MAGIC_ERROR_CODES.PAYMENT_FAILED,
+                  cancelled ? 'user_cancelled' : 'gateway_error',
+                  data
+                )
+              );
+            },
+          });
+
+          // Exactly the option set the modal needs. Magic activates from the
+          // order's line_items_total plus the merchant's server-side 1CC
+          // feature flag, so no cart, price, or shop id ever needs to travel
+          // to the device here.
+          host.open({ key, order_id, one_click_checkout: true });
+        });
+      });
+  };
+}

--- a/src/magic/core/openMagicCheckout.js
+++ b/src/magic/core/openMagicCheckout.js
@@ -16,6 +16,17 @@ function validate(options) {
   return null;
 }
 
+// client.js only ever rejects with a MagicCheckoutError, but this promise is
+// public API surface -- a future client swap, or any other rejection shape
+// (a string, a plain object), must not throw trying to attach `.details`.
+// Normalising here means the handle always has somewhere safe to land.
+function asMagicCheckoutError(err, reason) {
+  if (err instanceof MagicCheckoutError) return err;
+  return new MagicCheckoutError(MAGIC_ERROR_CODES.COMPLETE_FAILED, reason, {
+    original: err instanceof Error ? err.message : err,
+  });
+}
+
 export function makeOpenMagicCheckout({ host, client }) {
   return function openMagicCheckout(options) {
     const invalidReason = validate(options);
@@ -37,43 +48,78 @@ export function makeOpenMagicCheckout({ host, client }) {
             unsubscribe = null;
           };
 
+          // The native bridge is not contractually limited to one event per
+          // checkout, and phase 3 can be in flight for the whole ~8s poll
+          // budget while the subscription is technically still live. A late
+          // second event -- success after a dismissal, or a stray error
+          // after success -- must not be allowed to rewrite an outcome that
+          // already happened: a placed, paid order reported as cancelled, or
+          // `complete` called after the user closed the modal. `settled` is
+          // flipped the instant the first event is accepted, paired with
+          // `release()` so both effects land atomically; every path after
+          // that point is a guaranteed no-op for any later event.
+          let settled = false;
+          const acceptEvent = () => {
+            if (settled) return false;
+            settled = true;
+            release();
+            return true;
+          };
+
           unsubscribe = host.subscribe({
             onSuccess: (data) => {
-              // The handle is the only way to recover a captured payment whose
-              // order never got placed, so it is built the instant onSuccess
-              // fires -- never inside a catch -- and threaded through every
-              // phase-3 outcome from here on, success or failure.
+              if (!acceptEvent()) return;
+
+              // The bridge does not guarantee a well-formed payload. We
+              // already have order_id (phase 1) and key (caller options), so
+              // even a garbage/empty payload still gets a handle a merchant
+              // can use to look up the payment by order id -- a promise that
+              // hangs forever after money has moved is the one outcome we
+              // must never produce.
+              const safe = data || {};
               const handle = {
-                razorpay_order_id: data.razorpay_order_id || order_id,
-                razorpay_payment_id: data.razorpay_payment_id,
-                razorpay_signature: data.razorpay_signature,
+                razorpay_order_id: safe.razorpay_order_id || order_id,
+                razorpay_payment_id: safe.razorpay_payment_id,
+                razorpay_signature: safe.razorpay_signature,
                 key,
               };
+
+              if (!handle.razorpay_payment_id) {
+                reject(
+                  new MagicCheckoutError(
+                    MAGIC_ERROR_CODES.COMPLETE_FAILED,
+                    'invalid_success_payload',
+                    { handle }
+                  )
+                );
+                return;
+              }
+
               client
                 .complete(key, experiments, handle)
                 .then((result) => {
-                  release();
                   resolve({
                     order_id: result.data.order_id,
                     order_status_url: result.data.order_status_url,
+                    total_amount: result.data.total_amount,
                     payment_id: handle.razorpay_payment_id,
                     status: result.status,
                   });
                 })
                 .catch((err) => {
-                  release();
-                  // Every phase-3 rejection must carry the handle -- it is the
-                  // on-call recovery path for a payment that was captured but
-                  // never turned into a Shopify order.
-                  err.details = Object.assign({}, err.details, { handle });
-                  reject(err);
+                  // Every phase-3 rejection must carry the handle -- it is
+                  // the on-call recovery path for a payment that was
+                  // captured but never turned into a Shopify order.
+                  const normalized = asMagicCheckoutError(err, 'non_error_rejection');
+                  normalized.details = Object.assign({}, normalized.details, { handle });
+                  reject(normalized);
                 });
             },
             onError: (data) => {
-              // A dismissal means no payment was taken. Phase 3 (`complete`)
-              // must never run here -- there is nothing to place and nothing
-              // to recover, so we release the listener and reject directly.
-              release();
+              if (!acceptEvent()) return;
+              // A dismissal (or native error) means no payment was taken.
+              // Phase 3 (`complete`) must never run here -- there is nothing
+              // to place and nothing to recover.
               const cancelled = data && data.code === NATIVE_PAYMENT_CANCELED;
               reject(
                 new MagicCheckoutError(
@@ -87,11 +133,24 @@ export function makeOpenMagicCheckout({ host, client }) {
             },
           });
 
-          // Exactly the option set the modal needs. Magic activates from the
-          // order's line_items_total plus the merchant's server-side 1CC
-          // feature flag, so no cart, price, or shop id ever needs to travel
-          // to the device here.
-          host.open({ key, order_id, one_click_checkout: true });
+          try {
+            // Exactly the option set the modal needs. Magic activates from
+            // the order's line_items_total plus the merchant's server-side
+            // 1CC feature flag, so no cart, price, or shop id ever needs to
+            // travel to the device here.
+            host.open({ key, order_id, one_click_checkout: true });
+          } catch (e) {
+            // A host that throws synchronously on open() must not leave the
+            // listener registered -- there will be no PAYMENT_SUCCESS or
+            // PAYMENT_ERROR event coming to release it otherwise.
+            if (acceptEvent()) {
+              reject(
+                new MagicCheckoutError(MAGIC_ERROR_CODES.PAYMENT_FAILED, 'host_open_threw', {
+                  message: e && e.message,
+                })
+              );
+            }
+          }
         });
       });
   };

--- a/src/magic/core/openMagicCheckout.js
+++ b/src/magic/core/openMagicCheckout.js
@@ -20,11 +20,18 @@ function validate(options) {
 // public API surface -- a future client swap, or any other rejection shape
 // (a string, a plain object), must not throw trying to attach `.details`.
 // Normalising here means the handle always has somewhere safe to land.
-function asMagicCheckoutError(err, reason) {
+//
+// The reason is derived, not passed in: "our own SDK threw a TypeError" and
+// "the client rejected with a bare string" are different incidents, and `reason`
+// is the field an on-call engineer splits MAGIC_COMPLETE_FAILED by first.
+function asMagicCheckoutError(err) {
   if (err instanceof MagicCheckoutError) return err;
-  return new MagicCheckoutError(MAGIC_ERROR_CODES.COMPLETE_FAILED, reason, {
-    original: err instanceof Error ? err.message : err,
-  });
+  const isError = err instanceof Error;
+  return new MagicCheckoutError(
+    MAGIC_ERROR_CODES.COMPLETE_FAILED,
+    isError ? `unexpected_${err.name}` : 'non_error_rejection',
+    { original: isError ? err.message : err }
+  );
 }
 
 export function makeOpenMagicCheckout({ host, client }) {
@@ -40,7 +47,7 @@ export function makeOpenMagicCheckout({ host, client }) {
 
     return client
       .init(key, { cart_id, storefront_access_token })
-      .then(({ order_id, experiments }) => {
+      .then(({ order_id, experiments, poll_budget_ms }) => {
         return new Promise((resolve, reject) => {
           let unsubscribe = null;
           const release = () => {
@@ -96,7 +103,7 @@ export function makeOpenMagicCheckout({ host, client }) {
               }
 
               client
-                .complete(key, experiments, handle)
+                .complete(key, experiments, handle, poll_budget_ms)
                 .then((result) => {
                   resolve({
                     order_id: result.data.order_id,
@@ -110,7 +117,7 @@ export function makeOpenMagicCheckout({ host, client }) {
                   // Every phase-3 rejection must carry the handle -- it is
                   // the on-call recovery path for a payment that was
                   // captured but never turned into a Shopify order.
-                  const normalized = asMagicCheckoutError(err, 'non_error_rejection');
+                  const normalized = asMagicCheckoutError(err);
                   normalized.details = Object.assign({}, normalized.details, { handle });
                   reject(normalized);
                 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,3 +70,29 @@ export type ExternalWalletData = {
   external_wallet: string;
   [key: string]: any;
 };
+
+export type MagicCheckoutOptions = {
+  /** Razorpay public key_id. Authenticates the init call and identifies the merchant. */
+  key: string;
+  /** The app's Shopify Storefront access token. Only the app that created a cart can read it. */
+  storefront_access_token: string;
+  /** Storefront cart id, e.g. "gid://shopify/Cart/c1-abc". An identifier — never a cart object. */
+  cart_id: string;
+};
+
+export type MagicCheckoutResult = {
+  /** Shopify order id. Undefined while status is 'pending'. */
+  order_id?: string;
+  order_status_url?: string;
+  total_amount?: number;
+  payment_id: string;
+  /** 'placed' — Shopify order exists. 'pending' — accepted, being placed asynchronously. */
+  status: 'placed' | 'pending';
+};
+
+export type MagicHandle = {
+  razorpay_order_id: string;
+  razorpay_payment_id: string;
+  razorpay_signature: string;
+  key: string;
+};


### PR DESCRIPTION
## What this adds

`RazorpayCheckout.openMagicCheckout({ key, storefront_access_token, cart_id })` — Shopify Magic Checkout (1CC) for React Native apps, in one SDK call.

```
1. POST /v1/magic/shopify/init   → { order_id, experiments }
2. open({ key, order_id, one_click_checkout: true })   ← existing native path, UNCHANGED
3. POST 1cc/shopify/complete     → bounded, then resolve
```

Between steps 2 and 3 a real payment is captured. Most of the design exists to make that window safe.

**Also:** the repo's first test infrastructure (it had none), and an extraction of `open()`'s listener wiring so a Magic flow can continue past first success.

**No native code changes. No `checkout.js` changes.** `ios/` and `android/` are untouched.

## `open()` is unchanged — verified, not asserted

`RazorpayCheckout.js` was refactored to delegate to `src/internal/checkoutSession.js`. The merge review compared it line-by-line against merge-base on all seven observable properties and ran **9 mutations, each caught by exactly one test, with zero vacuous tests**.

Two known quirks are deliberately **frozen, not fixed**, and commented as such — "fixing" either breaks its guarding test:
- teardown is global, not per-call;
- `onExternalWalletSelection` tears down the payment listeners.

Existing integrations upgrade with no behaviour change.

## Design decisions worth reviewing

**`complete` confirms receipt, not placement.** Once the backend has the request, its worker owns placement. So `DELEGATED_TO_SQS`, `ALREADY_PLACED` and budget exhaustion all **resolve** as `{status: 'pending'}`. Rejecting any of them would tell a shopper their order failed while it is being placed.

**The recovery handle is built before phase 3, never in a catch,** and every phase-3 rejection carries it in `error.details.handle`. The README warns against blind-logging that object — it contains `razorpay_signature`.

**A terminal latch: first event wins.** The bridge can emit more than one event and the subscription stays live for the whole phase-3 window. Without the latch, a late error after a landed completion reported a placed, paid order as `MAGIC_CHECKOUT_CANCELLED`.

**No amounts leave the device.** `cart_id` is an identifier; passing a cart object is rejected before any network call.

**Platform-neutral core.** `src/magic/core/` has zero `react-native` imports, enforced by a guard verified to recurse into subdirectories. `host` and `http` are injected ports — which is why 75 tests run with no device, no Shopify store and no merchant key, and why a Flutter or Capacitor wrapper would be an adapter rather than a rewrite.

## How this was reviewed

Every task had an independent review; findings were verified by **mutation** — break the code, confirm a test catches it. That found **five separate cases of tests that were green but structurally incapable of failing**, none of which would ever have surfaced as a red test.

The orchestrator was rejected on first review with three Criticals, each proven by running probe:
- a null `PAYMENT_SUCCESS` payload left the promise pending forever **after capture** — shopper charged, app hung, no error;
- no terminal latch (above);
- `total_amount` silently dropped.

The whole-branch review then found two merge-blockers:
- **phase 3 could hang indefinitely** — `http.post` had no timeout and the budget was only checked *between* attempts. RN's `fetch` sets no `xhr.timeout`, so Android was genuinely unbounded. Now aborted per-attempt against the remaining budget, with the abort path traced through to `client.js`'s transport-error classification so the existing retry applies.
- **the README documented an impossible recovery procedure.** Corrected to state what the SDK can actually deliver.

## Known gaps, deliberately not addressed here

- `RETRY_FAILED` is treated as `pending`; whether it is terminal needs a backend answer. If terminal, the "confirming your order" copy would be wrong for a refunded order.
- No telemetry — the design's `MAGIC_*` log names are unimplemented.
- The handle reaches the app only on a rejection, so an app killed before that cannot recover client-side. Surfacing it proactively is a follow-up.
- `client.init` is still unbounded (pre-payment; a stuck spinner, not lost money).
- ~1 MB of pre-existing `sampleApps/` content still ships; trimming it needs a `files` allowlist.

Backend counterpart: `razorpay/1cc-consumer-app#1087`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
